### PR TITLE
Fix flash handling, naming conventions, and minor bugs (#PR1)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   layout -> { devise_controller? ? 'devise' : 'application' }
 
-  inertia_share auth: -> { { user: current_user } }, flash: -> { flash.to_hash }
+  inertia_share auth: -> { { user: current_user } }
 
   def after_sign_in_path_for(resource_or_scope)
     pair_requests_path

--- a/app/controllers/users/pair_requests_controller.rb
+++ b/app/controllers/users/pair_requests_controller.rb
@@ -16,7 +16,6 @@ class Users::PairRequestsController < ApplicationController
     @pair_request = current_user.pair_requests.build
     
     render inertia: 'Users/PairRequests/New', props: {
-      pair_request: @pair_request,
       tags: TagResource.new(Tag.select(:id, :name))
     }
   end

--- a/app/javascript/components/FlashMessages.jsx
+++ b/app/javascript/components/FlashMessages.jsx
@@ -2,7 +2,7 @@ import { usePage } from '@inertiajs/react';
 import { useState, useEffect } from 'react';
 
 export default function FlashMessages() {
-  const { flash } = usePage().props;
+  const { flash } = usePage();
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {

--- a/app/javascript/pages/Activities.jsx
+++ b/app/javascript/pages/Activities.jsx
@@ -31,7 +31,7 @@ export default function Activities ({ activities }) {
                   creating a pair request
                 </Link>{" "}
                 or maybe{" "}
-                <Link href="pair_requests" className="font-bold underline text-purple">
+                <Link href="/pair_requests" className="font-bold underline text-purple">
                   sending an offer
                 </Link>
               </p>

--- a/app/javascript/pages/Home.jsx
+++ b/app/javascript/pages/Home.jsx
@@ -1,5 +1,6 @@
 import InfoCard from "@/components/InfoCard";
-import LandingNav from "../components/LandingNav";
+import FlashMessages from "@/components/FlashMessages";
+import LandingNav from "@/components/LandingNav";
 import collaborateImage from "@/assets/images/collaborate.svg";
 import arrowImage from "@/assets/images/arrow.svg"
 import logoImage from "@/assets/images/logo.svg";
@@ -11,10 +12,11 @@ import postNewImg from "@/assets/images/post_new.svg";
 import reviewImg from "@/assets/images/review.svg";
 import acceptImg from "@/assets/images/accept.svg";
 
-export default function Home(props) {
+export default function Home({ auth }) {
   return (
     <div>
-      <LandingNav user={props.auth.user} />
+      <FlashMessages />
+      <LandingNav user={auth.user} />
       <div className="w-full flex justify-center">
         <div className="flex w-full md:w-1/2 justify-center px-5 py-12 md:px-12 lg:px-16 lg:py-24">
           <div className="text-center">

--- a/app/javascript/pages/Profile.jsx
+++ b/app/javascript/pages/Profile.jsx
@@ -2,7 +2,7 @@ import { Head, useForm } from "@inertiajs/react";
 import Reveal from "@/components/Reveal"
 import { useState } from "react";
 
-export default function Show({ user, countries, languages, levels }) {
+export default function Profile({ user, countries, languages, levels }) {
   const { data, setData, patch, errors, processing } = useForm({
     name: user.name || "",
     profession: user.profession || "",

--- a/app/javascript/pages/Sessions/Card.jsx
+++ b/app/javascript/pages/Sessions/Card.jsx
@@ -1,4 +1,5 @@
 import { useForm } from "@inertiajs/react";
+import { formatShort } from "@/helpers/date";
 
 export default function Card({ session }) {
   const { data, setData, patch, processing } = useForm({
@@ -34,11 +35,11 @@ export default function Card({ session }) {
         <div className="w-full mt-6 md:mt-0 md:w-1/2">
           <div className="w-full flex items-center justify-center md:justify-end gap-x-1">
             <div className="rounded-xl text-sm border-2 border-black px-3 py-0.5 font-semibold bg-white">
-              {session.start_at}
+              {formatShort(session.start_at)}
             </div>
             <span className="block font-bold">:</span>
             <div className="rounded-xl text-sm border-2 border-black px-3 py-0.5 font-semibold bg-white">
-              {session.end_at}
+              {formatShort(session.end_at)}
             </div>
           </div>
         </div>

--- a/app/javascript/pages/Users/PairRequests/Card.jsx
+++ b/app/javascript/pages/Users/PairRequests/Card.jsx
@@ -2,7 +2,7 @@ import { useForm, Link } from '@inertiajs/react';
 import { useState, useEffect, useRef } from 'react';
 import { formatShort } from "@/helpers/date";
 
-export default function RequestCard({ request }) {
+export default function Card({ request }) {
   const [expanded, setExpanded] = useState(false);
   const [showButton, setShowButton] = useState(false);
   const contentRef = useRef(null);

--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -4,4 +4,5 @@ InertiaRails.configure do |config|
   config.version = ViteRuby.digest
   config.encrypt_history = true
   config.always_include_errors_hash = true
+  config.flash_keys = %i[notice alert error]
 end


### PR DESCRIPTION
- Move flash to gem-managed top-level: add flash_keys config, remove manual inertia_share, fix FlashMessages to use usePage().flash
- Add FlashMessages to Home so sign-out notice is not silently dropped
- Fix Activities link missing leading slash (would break from nested routes)
- Remove unused pair_request prop from Users::PairRequestsController#new
- Apply formatShort to session dates in Sessions/Card
- Rename exports: Show→Profile, RequestCard→Card
- Destructure auth prop in Home, fix @/ alias for LandingNav import

https://www.awesomescreenshot.com/video/52416469?key=10e5fbc22fced4da7552dca591290c3f