### PR TITLE
Fix controller bugs and bring server layer up to Inertia conventions

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -5,7 +5,7 @@ class ActivitiesController < ApplicationController
     @activities = Activity.where(receiver: current_user).order(created_at: :desc)
 
     render inertia: "Activities", props: {
-      activities: @activities
+      activities: @activities.as_json(only: [:id, :title, :content])
     }
   end
 end

--- a/app/controllers/pair_requests/offers_controller.rb
+++ b/app/controllers/pair_requests/offers_controller.rb
@@ -11,7 +11,7 @@ class PairRequests::OffersController < ApplicationController
     
     render inertia: 'PairRequests/Offers/Index', props: {
       offers: ReceivedOfferResource.new(@offers),
-      pair_request_id: @pair_request.id
+      pairRequestId: @pair_request.id
     }
   end
 
@@ -22,7 +22,7 @@ class PairRequests::OffersController < ApplicationController
     authorize @offer, :create?, policy_class: PairRequests::OfferPolicy
 
     render inertia: 'PairRequests/Offers/New', props: {
-      pair_request_id: @pair_request.id,
+      pairRequestId: @pair_request.id,
       periods: @pair_request.periods.future.map { |p|
         { id: p.id, start_at: p.start_at, end_at: p.end_at }
       }
@@ -38,7 +38,7 @@ class PairRequests::OffersController < ApplicationController
     if @offer.save
       redirect_to pair_requests_path, notice: "We have sent your offer, good luck!"
     else
-      redirect_to new_pair_request_offer_path(@pair_request), inertia: { errors: @offer.errors }
+      redirect_to new_pair_request_offer_path(@pair_request), inertia: { errors: @offer.errors.to_hash(true) }
     end
   end
 
@@ -50,8 +50,8 @@ class PairRequests::OffersController < ApplicationController
     Offers::Accept
       .call(offer)
       .either(
-        -> (success) { redirect_to pair_request_offers_path, notice: "You just scheduled yourself a new pairing session. Happy pairin!" },
-        -> (failure) { render :index, status: :unprocessable_entity }
+        -> (success) { redirect_to pair_request_offers_path(offer.pair_request_id), notice: "You just scheduled yourself a new pairing session. Happy pairin!" },
+        -> (failure) { redirect_to pair_request_offers_path(offer.pair_request_id), alert: "Could not accept offer." }
       )
   end
 

--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -24,10 +24,12 @@ class PairRequestsController < ApplicationController
           }
         )
       },
-      filterOptions: {
-        tags: Tag.all.as_json(only: [:id, :name]),
-        userLevels: User::LEVELS,
-        languages: I18nData.languages.map { |k, v| [v, k] }
+      filterOptions: InertiaRails.once {
+        {
+          tags: Tag.all.as_json(only: [:id, :name]),
+          userLevels: User::LEVELS,
+          languages: I18nData.languages.map { |k, v| [v, k] }
+        }
       }
     }
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,9 +3,9 @@ class ProfilesController < ApplicationController
 
   def show
     @user = current_user
-    
+
     render inertia: 'Profile', props: {
-      user: current_user.as_json(methods: [:image_url]),
+      user: current_user.as_json(only: [:id, :name, :profession, :about, :date_of_birth, :programming_since, :language, :country, :level], methods: [:image_url]),
       languages: I18nData.languages.invert.to_a,
       countries: I18nData.countries.invert.to_a,
       levels: User::LEVELS.map { |l| [l.capitalize, l] }
@@ -14,17 +14,11 @@ class ProfilesController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    
+
     if @user.update(profile_attributes)
       redirect_to profile_path(@user.id), notice: "Your profile has been updated!"
     else
-      render inertia: 'Profile', props: {
-        user: @user.as_json(methods: [:image_url]),
-        languages: I18nData.languages.invert.to_a,
-        countries: I18nData.countries.invert.to_a,
-        levels: User::LEVELS.map { |l| [l.capitalize, l] },
-        errors: @user.errors
-      }
+      redirect_back_or_to profile_path(@user), inertia: { errors: @user.errors.to_hash(true) }
     end
   end
 

--- a/app/controllers/users/pair_requests_controller.rb
+++ b/app/controllers/users/pair_requests_controller.rb
@@ -8,7 +8,7 @@ class Users::PairRequestsController < ApplicationController
       .order(created_at: :desc)
 
     render inertia: 'Users/PairRequests/Index', props: {
-      pair_requests: PairRequestResource.new(@pair_requests)
+      pairRequests: PairRequestResource.new(@pair_requests)
     }
   end
 
@@ -26,10 +26,7 @@ class Users::PairRequestsController < ApplicationController
     if @pair_request.save
       redirect_to users_pair_requests_path, notice: "Request posted! Good luck"
     else
-      render inertia: 'Users/PairRequests/New', props: {
-        pair_request: @pair_request,
-        tags: TagResource.new(Tag.select(:id, :name))
-      }, status: :unprocessable_entity
+      redirect_back_or_to new_users_pair_request_path, inertia: { errors: @pair_request.errors.to_hash(true) }
     end
   end
 

--- a/app/javascript/pages/PairRequests/Offers/Card.jsx
+++ b/app/javascript/pages/PairRequests/Offers/Card.jsx
@@ -25,9 +25,9 @@ export default function Card({ offer, pairRequestId }) {
 
       <div className="flex items-center gap-x-2 px-4 pt-4">
         <figure className="border-2 border-black w-12 h-12 overflow-hidden rounded-md shrink-0">
-          <img src={offer.offerer.image_url} alt={offer.offerer.email} className="w-full h-full object-cover" />
+          <img src={offer.offerer.image_url} alt={offer.offerer.name} className="w-full h-full object-cover" />
         </figure>
-        <p>{offer.offerer.email}</p>
+        <p>{offer.offerer.name}</p>
         {offer.status === "ACCEPTED" && (
           <span className="ml-auto bg-green-400 border-2 border-black px-2 py-1 rounded-md text-xs font-bold shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
             ACCEPTED

--- a/app/javascript/pages/PairRequests/Offers/Index.jsx
+++ b/app/javascript/pages/PairRequests/Offers/Index.jsx
@@ -1,7 +1,7 @@
 import { Head } from "@inertiajs/react";
 import Card from './Card';
 
-export default function Index({ offers, pair_request_id }) {
+export default function Index({ offers, pairRequestId }) {
   return (
     <div className="flex flex-col items-center">
       <Head title="Applications" />
@@ -14,7 +14,7 @@ export default function Index({ offers, pair_request_id }) {
         <div className="mt-12">
           {offers.length > 0 ? (
             offers.map((offer) => (
-              <Card key={offer.id} offer={offer} pairRequestId={pair_request_id} />
+              <Card key={offer.id} offer={offer} pairRequestId={pairRequestId} />
             ))
           ) : (
             <div className="border-4 border-dashed border-black rounded-md p-12 text-center bg-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">

--- a/app/javascript/pages/PairRequests/Offers/New.jsx
+++ b/app/javascript/pages/PairRequests/Offers/New.jsx
@@ -1,7 +1,7 @@
 import { useForm, Head } from '@inertiajs/react';
 import { formatShort } from "@/helpers/date";
 
-export default function New({ pair_request_id, periods }) {
+export default function New({ pairRequestId, periods }) {
   const { data, setData, post, processing, errors } = useForm({
     message: '',
     period_id: periods[0]?.id || ''
@@ -9,7 +9,7 @@ export default function New({ pair_request_id, periods }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    post(`/pair_requests/${pair_request_id}/offers`);
+    post(`/pair_requests/${pairRequestId}/offers`);
   };
 
   return (

--- a/app/javascript/pages/Users/PairRequests/Index.jsx
+++ b/app/javascript/pages/Users/PairRequests/Index.jsx
@@ -1,7 +1,7 @@
 import { Head } from '@inertiajs/react';
 import Card from './Card';
 
-export default function Index({ pair_requests }) {
+export default function Index({ pairRequests }) {
   return (
     <div className="flex justify-center">
       <Head title="Your Requests" />
@@ -12,8 +12,8 @@ export default function Index({ pair_requests }) {
         </div>
 
         <div className="mt-12">
-          {pair_requests && pair_requests.length > 0 ? (
-            pair_requests.map((request) => (
+          {pairRequests && pairRequests.length > 0 ? (
+            pairRequests.map((request) => (
               <Card key={request.id} request={request} />
             ))
           ) : (

--- a/app/resources/received_offer_resource.rb
+++ b/app/resources/received_offer_resource.rb
@@ -3,7 +3,7 @@ class ReceivedOfferResource < ApplicationResource
 
   attribute :offerer do |offer|
     {
-      email: offer.offerer.email,
+      name: offer.offerer.name,
       image_url: offer.offerer.image_url
     }
   end


### PR DESCRIPTION
- PRG: ProfilesController#update, OffersController#create, and PairRequestsController#create now redirect on validation failure with errors.to_hash(true) instead of re-rendering inline
- Fix broken OffersController#accept: success and failure paths both called pair_request_offers_path without required pair_request_id (pre-existing routing error); both now pass offer.pair_request_id
- Whitelist fields in ProfilesController as_json to avoid leaking all user columns to the frontend
- Serialize ActivitiesController with explicit only: fields
- Wrap filterOptions in InertiaRails.once so tags/levels/languages are not re-queried on every partial reload
- Add offerer.name to ReceivedOfferResource; update Card to display name instead of email
- Normalize snake_case props to camelCase: pair_request_id → pairRequestId, pair_requests → pairRequests across controllers and their page components