### PR TITLE
Fix frontend form patterns, URL-driven filter state and extract Read More

### DIFF
--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -9,11 +9,13 @@ class PairRequestsController < ApplicationController
 
     @q = base.ransack(params[:q]&.compact_blank)
     @pagy, @pair_requests = pagy(
-      @q.result(distinct: true).order('periods.start_at ASC'), 
+      @q.result(distinct: true).order('periods.start_at ASC'),
       items: 15,
+      overflow: :empty_page,
     )
 
     render inertia: 'PairRequests/Index', props: {
+      filters: params[:q]&.compact_blank || {},
       pairRequests: InertiaRails.scroll(@pagy) {
         @pair_requests.as_json(
           include: {

--- a/app/javascript/components/ExpandableText.jsx
+++ b/app/javascript/components/ExpandableText.jsx
@@ -1,0 +1,29 @@
+import { useState, useEffect, useRef } from "react";
+
+export default function ExpandableText({ children, className = "" }) {
+  const [expanded, setExpanded] = useState(false);
+  const [showButton, setShowButton] = useState(false);
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    setShowButton(el.scrollHeight > el.clientHeight);
+  }, [children]);
+
+  return (
+    <>
+      <p ref={contentRef} className={`${expanded ? "" : "line-clamp-3"} ${className}`.trim()}>
+        {children}
+      </p>
+      {showButton && (
+        <button
+          className="mt-2 text-sm font-bold underline hover:text-purple"
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          {expanded ? "Read less" : "Read more"}
+        </button>
+      )}
+    </>
+  );
+}

--- a/app/javascript/components/FilterForm.jsx
+++ b/app/javascript/components/FilterForm.jsx
@@ -1,14 +1,13 @@
 import { useState } from "react";
-import { shiftDate } from "@/helpers/date";
 
-export default function FilterForm({ tags, userLevels, languages, onSubmit }) {
+export default function FilterForm({ tags, userLevels, languages, filters = {}, onSubmit }) {
   const [form, setForm] = useState({
-    tags_name_eq: "",
-    duration_eq: "",
-    user_level_eq: "",
-    user_language_eq: "",
-    starts_after: "",
-    starts_before: ""
+    tags_name_eq: filters.tags_name_eq || "",
+    duration_eq: filters.duration_eq || "",
+    user_level_eq: filters.user_level_eq || "",
+    user_language_eq: filters.user_language_eq || "",
+    periods_start_at_gteq: filters.periods_start_at_gteq || "",
+    periods_start_at_lteq: filters.periods_start_at_lteq || "",
   });
 
   const handleChange = (e) => {
@@ -18,16 +17,7 @@ export default function FilterForm({ tags, userLevels, languages, onSubmit }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-
-    const payload = {
-      ...form,
-      periods_start_at_gteq: form.starts_after ? shiftDate(form.starts_after, 0) : "",
-      periods_start_at_lteq: form.starts_before ? shiftDate(form.starts_before, 1) : ""
-    };
-
-    delete payload.starts_after;
-    delete payload.starts_before;
-    onSubmit(payload);
+    onSubmit(form);
   };
 
   return (
@@ -111,28 +101,28 @@ export default function FilterForm({ tags, userLevels, languages, onSubmit }) {
       </div>
 
       <div className="md:w-5/12">
-        <label htmlFor="starts_after" className="font-bold block mb-1">
+        <label htmlFor="periods_start_at_gteq" className="font-bold block mb-1">
           Session starts after
         </label>
         <input
           type="date"
-          id="starts_after"
-          name="starts_after"
-          value={form.starts_after}
+          id="periods_start_at_gteq"
+          name="periods_start_at_gteq"
+          value={form.periods_start_at_gteq}
           onChange={handleChange}
           className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none"
         />
       </div>
 
       <div className="md:w-5/12">
-        <label htmlFor="starts_before" className="font-bold block mb-1">
+        <label htmlFor="periods_start_at_lteq" className="font-bold block mb-1">
           Session starts before
         </label>
         <input
           type="date"
-          id="starts_before"
-          name="starts_before"
-          value={form.starts_before}
+          id="periods_start_at_lteq"
+          name="periods_start_at_lteq"
+          value={form.periods_start_at_lteq}
           onChange={handleChange}
           className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none"
         />

--- a/app/javascript/pages/PairRequests/Card.jsx
+++ b/app/javascript/pages/PairRequests/Card.jsx
@@ -1,22 +1,9 @@
-import { useState, useEffect, useRef } from "react";
 import { Link } from "@inertiajs/react";
 import { formatShort } from "@/helpers/date";
 import logoImg from "@/assets/images/logo.svg"
+import ExpandableText from "@/components/ExpandableText";
 
 export default function Card({ pairRequest, currentUserId }) {
-  const [expanded, setExpanded] = useState(false);
-  const [showButton, setShowButton] = useState(false);
-  const contentRef = useRef(null);
-
-  
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-
-    const isOverflowing = el.scrollHeight > el.clientHeight;
-    setShowButton(isOverflowing);
-  }, []);
-
   const alreadyOffered = pairRequest.offers
     ?.map(o => o.offerer_id)
     .includes(currentUserId);
@@ -29,14 +16,7 @@ export default function Card({ pairRequest, currentUserId }) {
 
       <div className="md:flex max-h-fit px-2 py-4">
         <div className="w-full md:w-7/12">
-          <p ref={contentRef} className={`${expanded ? "line-clamp-none" : "line-clamp-3"}`}>
-              {pairRequest.description}
-          </p>
-          {showButton && (
-            <button className="underline" onClick={() => setExpanded((prev) => !prev)}>
-              {expanded ? "Read less" : "Read more"}
-            </button>
-          )}
+          <ExpandableText>{pairRequest.description}</ExpandableText>
         </div>
 
         <div className="w-full mt-4 md:mt-0 md:w-5/12">

--- a/app/javascript/pages/PairRequests/Index.jsx
+++ b/app/javascript/pages/PairRequests/Index.jsx
@@ -4,7 +4,7 @@ import Card from "./Card";
 import { Head, router, usePage, InfiniteScroll } from "@inertiajs/react";
 import preferencesImg from "@/assets/images/preferences.svg";
 
-export default function Index({ pairRequests, filterOptions }) {
+export default function Index({ pairRequests, filterOptions, filters }) {
   const { auth } = usePage().props;
   const currentUser = auth.user;
 
@@ -35,8 +35,9 @@ export default function Index({ pairRequests, filterOptions }) {
                 tags={tags}
                 userLevels={userLevels}
                 languages={languages}
-                onSubmit={(filters) => {
-                  router.get("/pair_requests", { q: filters }, { preserveState: true });
+                filters={filters}
+                onSubmit={(q) => {
+                  router.get("/pair_requests", { q });
                 }}
               />
             </Reveal>

--- a/app/javascript/pages/PairRequests/Offers/Card.jsx
+++ b/app/javascript/pages/PairRequests/Offers/Card.jsx
@@ -1,18 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
 import { router } from '@inertiajs/react';
 import { formatShort } from "@/helpers/date";
+import ExpandableText from "@/components/ExpandableText";
 
 export default function Card({ offer, pairRequestId }) {
-  const [expanded, setExpanded] = useState(false);
-  const [showButton, setShowButton] = useState(false);
-  const contentRef = useRef(null);
-
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-    setShowButton(el.scrollHeight > el.clientHeight);
-  }, [offer.message]);
-
   const handleAccept = () => {
     router.post(`/pair_requests/${pairRequestId}/offers/${offer.id}/accept`);
   };
@@ -36,17 +26,7 @@ export default function Card({ offer, pairRequestId }) {
       </div>
 
       <div className="px-2 py-4">
-        <p ref={contentRef} className={`whitespace-pre-wrap ${expanded ? "" : "line-clamp-3"}`}>
-          {offer.message}
-        </p>
-        {showButton && (
-          <button
-            className="mt-2 text-sm font-bold underline hover:text-purple"
-            onClick={() => setExpanded(!expanded)}
-          >
-            {expanded ? "Read less" : "Read more"}
-          </button>
-        )}
+        <ExpandableText className="whitespace-pre-wrap">{offer.message}</ExpandableText>
       </div>
 
       <div className="px-4 md:flex md:items-center">

--- a/app/javascript/pages/PairRequests/Offers/New.jsx
+++ b/app/javascript/pages/PairRequests/Offers/New.jsx
@@ -1,17 +1,7 @@
-import { useForm, Head } from '@inertiajs/react';
+import { Form, Head } from '@inertiajs/react';
 import { formatShort } from "@/helpers/date";
 
 export default function New({ pairRequestId, periods }) {
-  const { data, setData, post, processing, errors } = useForm({
-    message: '',
-    period_id: periods[0]?.id || ''
-  });
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    post(`/pair_requests/${pairRequestId}/offers`);
-  };
-
   return (
     <div className="flex flex-col items-center w-full px-4">
       <Head title="Send application" />
@@ -20,50 +10,52 @@ export default function New({ pairRequestId, periods }) {
           <h3 className="text-5xl font-bold">Send application</h3>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col items-start mt-12">
-          <div className="w-full">
-            <label className="block font-bold mb-1">Message</label>
-            <textarea
-              value={data.message}
-              onChange={e => setData('message', e.target.value)}
-              rows="4"
-              className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-            />
-            {errors.message && (
-              <div className="text-red-600 font-bold mt-1">{errors.message}</div>
-            )}
-          </div>
+        <Form method="post" action={`/pair_requests/${pairRequestId}/offers`} className="flex flex-col items-start mt-12">
+          {({ errors, processing }) => (
+            <>
+              <div className="w-full">
+                <label className="block font-bold mb-1">Message</label>
+                <textarea
+                  name="message"
+                  rows="4"
+                  className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                />
+                {errors.message && (
+                  <div className="text-red-600 font-bold mt-1">{errors.message}</div>
+                )}
+              </div>
 
-          <div className="w-full mt-4">
-            <label className="block font-bold mb-1">Select period</label>
-            <select
-              value={data.period_id}
-              onChange={e => setData('period_id', e.target.value)}
-              className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-            >
-              {periods.map(period => (
-                <option key={period.id} value={period.id}>
-                  {formatShort(period.start_at)} : {formatShort(period.end_at)}
-                </option>
-              ))}
-            </select>
-            {(errors.period || errors.period_id) && (
-              <div className="text-orange font-bold mt-1">{errors.period || errors.period_id}</div>
-            )}
-          </div>
+              <div className="w-full mt-4">
+                <label className="block font-bold mb-1">Select period</label>
+                <select
+                  name="period_id"
+                  defaultValue={periods[0]?.id || ''}
+                  className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                >
+                  {periods.map(period => (
+                    <option key={period.id} value={period.id}>
+                      {formatShort(period.start_at)} : {formatShort(period.end_at)}
+                    </option>
+                  ))}
+                </select>
+                {(errors.period || errors.period_id) && (
+                  <div className="text-orange font-bold mt-1">{errors.period || errors.period_id}</div>
+                )}
+              </div>
 
-          <div className="w-full flex justify-center">
-            <button
-              type="submit"
-              disabled={processing}
-              className="mt-12 flex cursor-pointer items-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
-            >
-              {processing ? 'Sending...' : 'Apply'}
-            </button>
-          </div>
-        </form>
+              <div className="w-full flex justify-center">
+                <button
+                  type="submit"
+                  disabled={processing}
+                  className="mt-12 flex cursor-pointer items-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
+                >
+                  {processing ? 'Sending...' : 'Apply'}
+                </button>
+              </div>
+            </>
+          )}
+        </Form>
       </div>
     </div>
   );
 }
-

--- a/app/javascript/pages/Profile.jsx
+++ b/app/javascript/pages/Profile.jsx
@@ -1,188 +1,171 @@
-import { Head, useForm } from "@inertiajs/react";
-import Reveal from "@/components/Reveal"
+import { Head, Form } from "@inertiajs/react";
+import Reveal from "@/components/Reveal";
 import { useState } from "react";
 
 export default function Profile({ user, countries, languages, levels }) {
-  const { data, setData, patch, errors, processing } = useForm({
-    name: user.name || "",
-    profession: user.profession || "",
-    about: user.about || "",
-    date_of_birth: user.date_of_birth ? user.date_of_birth.split("T")[0] : "1995-01-01",
-    programming_since: user.programming_since ? user.programming_since.split("T")[0] : "2015-01-01",
-    language: user.language || "",
-    country: user.country || "",
-    level: user.level || "",
-    image: null
-  });
-
   const [previewUrl, setPreviewUrl] = useState(user.image_url);
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
-    if (file) {
-      setData("image", file);
-      setPreviewUrl(URL.createObjectURL(file));
-    }
-  }
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    patch(`/profiles/${user.id}`, {
-      forceFormData: true,
-    });
-  }
+    if (file) setPreviewUrl(URL.createObjectURL(file));
+  };
 
   return (
     <div className="flex flex-col items-center w-full px-4">
-      <Head title={`${user.name}'s Profile`}/>
+      <Head title={`${user.name}'s Profile`} />
 
       <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        
-        <div className="flex flex-col items-center w-full mt-12 pb-8 border-b-4 border-black border-dashed text-center">
-          <h3 className="text-5xl font-bold mb-4">{user.name}</h3>
-          
-          <div className="w-32 h-32 border-black border-4 rounded-xl shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] overflow-hidden bg-white">
-            {previewUrl ? (
-              <img src={previewUrl} alt={data.name} className="w-full h-full object-contain" />
-            ) : (
-              <div className="w-full h-full bg-gray-200" />
-            )}
-          </div>
-          <div className="mt-4">
-            <Reveal
-              key={user.image_url}
-              button={
-                <button className="border-2 border-black rounded-xl px-2 font-bold hover:bg-gray-100 transition-colors">
-                  Change Avatar
-                </button>
-              }
-            >
-              <div className="mt-4">
-                <input
-                  type="file"
-                  onChange={handleFileChange}
-                  className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] bg-white"
-                />
+        <Form method="patch" action={`/profiles/${user.id}`}>
+          {({ errors, processing, progress }) => (
+            <>
+              <div className="flex flex-col items-center w-full mt-12 pb-8 border-b-4 border-black border-dashed text-center">
+                <h3 className="text-5xl font-bold mb-4">{user.name}</h3>
+
+                <div className="w-32 h-32 border-black border-4 rounded-xl shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] overflow-hidden bg-white">
+                  {previewUrl ? (
+                    <img src={previewUrl} alt={user.name} className="w-full h-full object-contain" />
+                  ) : (
+                    <div className="w-full h-full bg-gray-200" />
+                  )}
+                </div>
+
+                <div className="mt-4">
+                  <Reveal
+                    key={user.image_url}
+                    button={
+                      <button type="button" className="border-2 border-black rounded-xl px-2 font-bold hover:bg-gray-100 transition-colors">
+                        Change Avatar
+                      </button>
+                    }
+                  >
+                    <div className="mt-4">
+                      <input
+                        type="file"
+                        name="image"
+                        onChange={handleFileChange}
+                        className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] bg-white"
+                      />
+                    </div>
+                  </Reveal>
+                </div>
               </div>
-            </Reveal>             
-          </div>
-        </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col items-center mt-8 pb-20">
-          <div className="w-full flex flex-wrap md:flex-nowrap gap-4">
-            <div className="w-full md:w-1/2 text-left">
-              <label className="block font-bold mb-1">Name</label>
-              <input 
-                value={data.name}
-                onChange={e => setData("name", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              />
-              {errors.name && <div className="text-red-500 font-bold mt-1 text-sm">{errors.name}</div>}
-            </div>
+              <div className="flex flex-col items-center mt-8 pb-20">
+                {progress && (
+                  <progress value={progress.percentage ?? 0} max="100" className="w-full mb-4" />
+                )}
 
-            <div className="w-full md:w-1/2 text-left">
-              <label className="block font-bold mb-1">Profession</label>
-              <input
-                value={data.profession}
-                onChange={e => setData("profession", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              />
-            </div>
-          </div>
+                <div className="w-full flex flex-wrap md:flex-nowrap gap-4">
+                  <div className="w-full md:w-1/2 text-left">
+                    <label className="block font-bold mb-1">Name</label>
+                    <input
+                      name="name"
+                      defaultValue={user.name || ""}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    />
+                    {errors.name && <div className="text-red-500 font-bold mt-1 text-sm">{errors.name}</div>}
+                  </div>
 
-          <div className="w-full mt-6 text-left">
-            <label className="block font-bold mb-1">About</label>
-            <textarea 
-              rows="4"
-              value={data.about} 
-              onChange={e => setData("about", e.target.value)}
-              className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-            />
-          </div>
+                  <div className="w-full md:w-1/2 text-left">
+                    <label className="block font-bold mb-1">Profession</label>
+                    <input
+                      name="profession"
+                      defaultValue={user.profession || ""}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    />
+                  </div>
+                </div>
 
-          <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
-            <div className="w-full md:w-1/2 text-left">
-              <label className="block font-bold mb-1">Date of Birth</label>
-              <input
-                type="date"
-                max={new Date().toISOString().split("T")[0]}
-                value={data.date_of_birth}
-                onChange={e => setData("date_of_birth", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              />
-            </div>
+                <div className="w-full mt-6 text-left">
+                  <label className="block font-bold mb-1">About</label>
+                  <textarea
+                    name="about"
+                    rows="4"
+                    defaultValue={user.about || ""}
+                    className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                  />
+                </div>
 
-            <div className="w-full md:w-1/2 text-left">
-              <label className="block font-bold mb-1">Programming Since</label>
-              <input
-                type="date"
-                max={new Date().toISOString().split("T")[0]}
-                value={data.programming_since}
-                onChange={e => setData("programming_since", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              />
-            </div>            
-          </div>
+                <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
+                  <div className="w-full md:w-1/2 text-left">
+                    <label className="block font-bold mb-1">Date of Birth</label>
+                    <input
+                      type="date"
+                      name="date_of_birth"
+                      max={new Date().toISOString().split("T")[0]}
+                      defaultValue={user.date_of_birth ? user.date_of_birth.split("T")[0] : "1995-01-01"}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    />
+                  </div>
 
-          <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
-            <div className="w-full md:w-1/3 text-left">
-              <label className="block font-bold mb-1">Country</label>
-              <select
-                value={data.country}
-                onChange={e => setData("country", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              >
-                <option value="">Select a country</option>
-                {countries.map(([label, value]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </div>
+                  <div className="w-full md:w-1/2 text-left">
+                    <label className="block font-bold mb-1">Programming Since</label>
+                    <input
+                      type="date"
+                      name="programming_since"
+                      max={new Date().toISOString().split("T")[0]}
+                      defaultValue={user.programming_since ? user.programming_since.split("T")[0] : "2015-01-01"}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    />
+                  </div>
+                </div>
 
-            <div className="w-full md:w-1/3 text-left">
-              <label className="block font-bold mb-1">Language</label>
-              <select
-                value={data.language}
-                onChange={e => setData("language", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              >
-                <option value="">Select a language</option>
-                {languages.map(([label, value]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </div>
+                <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
+                  <div className="w-full md:w-1/3 text-left">
+                    <label className="block font-bold mb-1">Country</label>
+                    <select
+                      name="country"
+                      defaultValue={user.country || ""}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    >
+                      <option value="">Select a country</option>
+                      {countries.map(([label, value]) => (
+                        <option key={value} value={value}>{label}</option>
+                      ))}
+                    </select>
+                  </div>
 
-            <div className="w-full md:w-1/3 text-left">
-              <label className="block font-bold mb-1">Level</label>
-              <select
-                value={data.level}
-                onChange={e => setData("level", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
-              >
-                <option value="">Select a level</option>
-                {levels.map(([label, value]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
+                  <div className="w-full md:w-1/3 text-left">
+                    <label className="block font-bold mb-1">Language</label>
+                    <select
+                      name="language"
+                      defaultValue={user.language || ""}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    >
+                      <option value="">Select a language</option>
+                      {languages.map(([label, value]) => (
+                        <option key={value} value={value}>{label}</option>
+                      ))}
+                    </select>
+                  </div>
 
-          <button
-            type="submit"
-            disabled={processing}
-            className="mt-16 flex cursor-pointer items-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
-          >
-            {processing ? "Saving..." : "Save Changes"}
-          </button>
-        </form>
+                  <div className="w-full md:w-1/3 text-left">
+                    <label className="block font-bold mb-1">Level</label>
+                    <select
+                      name="level"
+                      defaultValue={user.level || ""}
+                      className="w-full rounded-md border-2 border-black p-[10px] font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none focus:translate-x-[3px] focus:translate-y-[3px] focus:shadow-none"
+                    >
+                      <option value="">Select a level</option>
+                      {levels.map(([label, value]) => (
+                        <option key={value} value={value}>{label}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={processing}
+                  className="mt-16 flex cursor-pointer items-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+                >
+                  {processing ? "Saving..." : "Save Changes"}
+                </button>
+              </div>
+            </>
+          )}
+        </Form>
       </div>
     </div>
-  )
+  );
 }

--- a/app/javascript/pages/Sessions/Card.jsx
+++ b/app/javascript/pages/Sessions/Card.jsx
@@ -1,16 +1,7 @@
-import { useForm } from "@inertiajs/react";
+import { Form } from "@inertiajs/react";
 import { formatShort } from "@/helpers/date";
 
 export default function Card({ session }) {
-  const { data, setData, patch, processing } = useForm({
-      call_link: session.call_link || "",
-  });
-
-  const submit = (e) => {
-    e.preventDefault();
-    patch(`/sessions/${session.id}`)
-  }
-
   return (
     <div className="mb-12 border-2 pb-4 border-black rounded-t-md bg-white shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       <div className="border-b-2 border-black py-4 px-2 rounded-t-md bg-green">
@@ -47,25 +38,28 @@ export default function Card({ session }) {
 
       <div className="w-full flex justify-center px-2">
         {session.is_holder ? (
-          <form onSubmit={submit} className="flex flex-col md:flex-row w-full gap-y-4 md:gap-x-2 items-center md:items-end justify-between">
-            <div className="flex flex-col justify-end w-full">
-              <label className="font-bold">Call link</label>
-              <input
-                value={data.call_link}
-                onChange={(e) => setData("call_link", e.target.value)}
-                className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[2px] focus:translate-y-[2px] focus:shadow-none"
-              />
-            </div>
+          <Form method="patch" action={`/sessions/${session.id}`} className="flex flex-col md:flex-row w-full gap-y-4 md:gap-x-2 items-center md:items-end justify-between">
+            {({ processing }) => (
+              <>
+                <div className="flex flex-col justify-end w-full">
+                  <label className="font-bold">Call link</label>
+                  <input
+                    name="call_link"
+                    defaultValue={session.call_link || ""}
+                    className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] outline-none transition-all focus:translate-x-[2px] focus:translate-y-[2px] focus:shadow-none"
+                  />
+                </div>
 
-            <button
-              type="submit"
-              disabled={processing}
-              className="w-3/4 md:w-1/4 flex cursor-pointer justify-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
-            >
-              {processing ? "..." : "Add"}
-            </button>
-
-          </form>
+                <button
+                  type="submit"
+                  disabled={processing}
+                  className="w-3/4 md:w-1/4 flex cursor-pointer justify-center rounded-md border-2 border-black bg-purple px-10 py-3 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
+                >
+                  {processing ? "..." : "Add"}
+                </button>
+              </>
+            )}
+          </Form>
         ) : (
           session.call_link ? (
             <a

--- a/app/javascript/pages/Users/Offers/Card.jsx
+++ b/app/javascript/pages/Users/Offers/Card.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
 import { formatShort } from "@/helpers/date";
+import ExpandableText from "@/components/ExpandableText";
 
 const StatusBadge = ({ status }) => {
   const styles = {
@@ -17,16 +17,6 @@ const StatusBadge = ({ status }) => {
 };
 
 export default function Card({ offer }) {
-  const [expanded, setExpanded] = useState(false);
-  const [showButton, setShowButton] = useState(false);
-  const contentRef = useRef(null);
-
-  useEffect(() => {
-    if (contentRef.current) {
-      setShowButton(contentRef.current.scrollHeight > contentRef.current.clientHeight);
-    }
-  }, []);
-
   return (
     <div className="mb-12 border-2 pb-4 border-black rounded-t-md bg-white shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       <div className="border-b-2 border-black px-2 py-3 rounded-t-md bg-green flex flex-col md:flex-row justify-between items-start md:items-center gap-y-2">
@@ -58,17 +48,7 @@ export default function Card({ offer }) {
       </div>
 
       <div className="px-2 py-4">
-        <p ref={contentRef} className={`whitespace-pre-wrap ${expanded ? "" : "line-clamp-3"}`}>
-          {offer.message}
-        </p>
-        {showButton && (
-          <button
-            className="mt-2 text-sm font-bold underline hover:text-purple"
-            onClick={() => setExpanded(!expanded)}
-          >
-            {expanded ? "Read less" : "Read more"}
-          </button>
-        )}
+        <ExpandableText className="whitespace-pre-wrap">{offer.message}</ExpandableText>
       </div>
 
       <div className="flex justify-end px-2">

--- a/app/javascript/pages/Users/PairRequests/Card.jsx
+++ b/app/javascript/pages/Users/PairRequests/Card.jsx
@@ -1,20 +1,8 @@
 import { useForm, Link } from '@inertiajs/react';
-import { useState, useEffect, useRef } from 'react';
 import { formatShort } from "@/helpers/date";
+import ExpandableText from "@/components/ExpandableText";
 
 export default function Card({ request }) {
-  const [expanded, setExpanded] = useState(false);
-  const [showButton, setShowButton] = useState(false);
-  const contentRef = useRef(null);
-
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-
-    const isOverflowing = el.scrollHeight > el.clientHeight;
-    setShowButton(isOverflowing);
-  }, [request.description]);
-  
   const { data, setData, patch, processing } = useForm({
     pair_request: {
       sessions_attributes: request.sessions.map(s => ({ 
@@ -42,14 +30,7 @@ export default function Card({ request }) {
       </div>
 
       <div className="px-4 py-4">
-        <p ref={contentRef} className={`${expanded ? "line-clamp-none" : "line-clamp-3"}`}>
-            {request.description}
-        </p>
-        {showButton && (
-          <button className="underline" onClick={() => setExpanded((prev) => !prev)}>
-            {expanded ? "Read less" : "Read more"}
-          </button>
-        )}
+        <ExpandableText>{request.description}</ExpandableText>
 
         <div className="flex w-full overflow-x-auto justify-start space-x-2 mt-4 pb-2">
           {request.tags?.map((tag) => (


### PR DESCRIPTION
- Convert useForm to <Form> in Offers/New, Profile, and Sessions/Card: file upload auto-detected by <Form>; useState kept for preview URL only; type="button" on Change Avatar to prevent accidental form submission
- Fix FilterForm URL state: controller passes filters: params[:q] back as prop; FilterForm seeds useState from it so form reflects active filters on refresh or shared URL; rename date fields to ransack names directly (periods_start_at_gteq/lteq) to eliminate the starts_after/starts_before mismatch; add overflow: :empty_page to pagy to prevent 500 on filter+scroll
- Extract ExpandableText component from 4 Card files (PairRequests/Card, PairRequests/Offers/Card, Users/Offers/Card, Users/PairRequests/Card)

https://www.awesomescreenshot.com/video/52463156?key=d8db444efd1f3c6004a7a1e07a2207dd