### PR TITLE
Set up neobrutalism lime theme tokens and Tailwind v3 translation

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,52 +9,42 @@
 
 @layer base {
   :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
+    /* neobrutalism lime theme — translated from neobrutalism.dev/styling */
+    --main: oklch(83.29% 0.2331 132.51);
+    --main-foreground: oklch(0% 0 0);
+    --background: oklch(95.37% 0.0549 125.19);
+    --secondary-background: oklch(100% 0 0);
+    --foreground: oklch(0% 0 0);
+    --border: oklch(0% 0 0);
+    --ring: oklch(0% 0 0);
+    --overlay: oklch(0% 0 0 / 0.8);
+    --shadow: 4px 4px 0px 0px var(--border);
+
+    /* shadcn compatibility — mapped to neobrutalism equivalents */
+    --card: oklch(100% 0 0);
+    --card-foreground: oklch(0% 0 0);
+    --popover: oklch(100% 0 0);
+    --popover-foreground: oklch(0% 0 0);
+    --primary: oklch(83.29% 0.2331 132.51);
+    --primary-foreground: oklch(0% 0 0);
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
     --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
+    --accent: oklch(83.29% 0.2331 132.51);
+    --accent-foreground: oklch(0% 0 0);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --radius: 0.625rem;
-  }
-  .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
+    --input: oklch(0% 0 0);
+    --radius: 0.3125rem;
   }
   * {
     border-color: var(--border);
   }
   body {
-    background-color: var(--background);
-    color: var(--foreground);
+    @apply bg-background text-foreground font-base;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading;
   }
 }
 
@@ -70,7 +60,8 @@ html {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: var(--read-more-line-clamp, 2)
+  -webkit-line-clamp: var(--read-more-line-clamp, 2);
+  line-clamp: var(--read-more-line-clamp, 2);
 }
 
 .input-primary {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,14 +10,39 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        // brand colors (used directly in layout/semantic contexts)
         orange: "#FF8B37",
         purple: "#7B5FF1",
         green: "#55D087",
-        background: "#E3E3FF"
+        // neobrutalism token colors (consumed by installed components)
+        main: 'var(--main)',
+        'main-foreground': 'var(--main-foreground)',
+        background: 'var(--background)',
+        'secondary-background': 'var(--secondary-background)',
+        foreground: 'var(--foreground)',
+        border: 'var(--border)',
+        ring: 'var(--ring)',
+        overlay: 'var(--overlay)',
       },
       fontFamily: {
         "sans": ["Cabin", "sans-serif"],
         "headline": ["Work Sans"]
+      },
+      fontWeight: {
+        base: '500',
+        heading: '700',
+      },
+      boxShadow: {
+        shadow: 'var(--shadow)',
+      },
+      borderRadius: {
+        base: '5px',
+      },
+      translate: {
+        boxShadowX: '4px',
+        boxShadowY: '4px',
+        reverseBoxShadowX: '-4px',
+        reverseBoxShadowY: '-4px',
       },
       animation: {
         marquee: "marquee 120s linear infinite",


### PR DESCRIPTION
Translates neobrutalism.dev/styling output (Tailwind v4) to v3:
- CSS variables for lime theme in application.tailwind.css
- @ theme inline block mapped to tailwind.config.js extensions
- shadcn compatibility variables mapped to neobrutalism equivalents
- Adds shadow-shadow, rounded-base, translate-boxShadowX/Y utilities