### PR TITLE
Fix routes typo, missing user fields on pair request cards, and profi…

### DIFF
--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -19,7 +19,7 @@ class PairRequestsController < ApplicationController
       pairRequests: InertiaRails.scroll(@pagy) {
         @pair_requests.as_json(
           include: {
-            user: { only: [:id, :name], methods: [:image_url] },
+            user: { only: [:id, :name, :profession], methods: [:image_url, :level_titleized] },
             tags: { only: [:id, :name] },
             periods: { only: [:id, :start_at, :end_at] },
             offers: { only: [:offerer_id] }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
   end
 
   def update
-    @user = User.find(params[:id])
+    @user = current_user
 
     if @user.update(profile_attributes)
       redirect_to profile_path(@user.id), notice: "Your profile has been updated!"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
   validates :country, inclusion: { in: I18nData.countries.keys }, allow_nil: true
   validates :level, inclusion: { in: LEVELS }, allow_nil: true
 
+  def level_titleized
+    level&.titleize
+  end
+
   class << self
     def ransackable_attributes(auth_object=nil)
       ["level", "language"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   end
 
   namespace :users do
-    resources :pair_requests, expect: [:edit, :update] do
+    resources :pair_requests, except: [:edit, :update] do
       patch :add_call_link, on: :member
     end
     resources :offers, only: [:index]


### PR DESCRIPTION
…le ownership

- Fix `expect:` → `except:` typo in users/pair_requests routes (was generating dead edit/update routes that have no controller actions)
- Add `profession` and `level_titleized` to user serialization in PairRequestsController so pair request cards correctly display the requester's profession and level
- Add `User#level_titleized` helper method (consistent with other Alba resources)
- Fix ProfilesController#update to use `current_user` instead of `User.find(params[:id])` to prevent any authenticated user from updating another user's profile