### PR TITLE
Redesign in-app UI: sidebar, theme, and page layouts

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,10 +9,10 @@
 
 @layer base {
   :root {
-    /* neobrutalism lime theme — translated from neobrutalism.dev/styling */
-    --main: oklch(83.29% 0.2331 132.51);
-    --main-foreground: oklch(0% 0 0);
-    --background: oklch(95.37% 0.0549 125.19);
+    /* pairin brand theme — purple primary, matched to the landing page palette */
+    --main: #7B5FF1;
+    --main-foreground: #FFFFFF;
+    --background: #FEFCE8;
     --secondary-background: oklch(100% 0 0);
     --foreground: oklch(0% 0 0);
     --border: oklch(0% 0 0);
@@ -20,22 +20,22 @@
     --overlay: oklch(0% 0 0 / 0.8);
     --shadow: 4px 4px 0px 0px var(--border);
 
-    /* shadcn compatibility — mapped to neobrutalism equivalents */
+    /* shadcn compatibility — mapped to brand equivalents */
     --card: oklch(100% 0 0);
     --card-foreground: oklch(0% 0 0);
     --popover: oklch(100% 0 0);
     --popover-foreground: oklch(0% 0 0);
-    --primary: oklch(83.29% 0.2331 132.51);
-    --primary-foreground: oklch(0% 0 0);
+    --primary: #7B5FF1;
+    --primary-foreground: #FFFFFF;
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
     --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(83.29% 0.2331 132.51);
-    --accent-foreground: oklch(0% 0 0);
+    --accent: #7B5FF1;
+    --accent-foreground: #FFFFFF;
     --destructive: oklch(0.577 0.245 27.325);
     --input: oklch(0% 0 0);
-    --radius: 0.3125rem;
+    --radius: 0.75rem;
   }
   * {
     border-color: var(--border);
@@ -44,7 +44,7 @@
     @apply bg-background text-foreground font-base;
   }
   h1, h2, h3, h4, h5, h6 {
-    @apply font-heading;
+    @apply font-display font-extrabold tracking-tight;
   }
 }
 

--- a/app/javascript/components/EmptyState.jsx
+++ b/app/javascript/components/EmptyState.jsx
@@ -1,0 +1,14 @@
+export default function EmptyState({ icon: Icon, title, description, children }) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-black bg-white px-8 py-16 text-center shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+      {Icon && (
+        <div className="mb-1 flex h-12 w-12 items-center justify-center rounded-xl border-2 border-black bg-yellow-50">
+          <Icon className="h-6 w-6 text-black/60" strokeWidth={2} />
+        </div>
+      )}
+      <p className="text-lg font-bold">{title}</p>
+      {description && <p className="max-w-sm text-black/50">{description}</p>}
+      {children}
+    </div>
+  );
+}

--- a/app/javascript/components/FilterForm.jsx
+++ b/app/javascript/components/FilterForm.jsx
@@ -31,11 +31,11 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
   };
 
   return (
-    <form
-      className="flex flex-col gap-4 mb-12 md:flex-row md:flex-wrap md:justify-between"
-      onSubmit={handleSubmit}
-    >
-      <div className="md:w-5/12">
+    <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+      <p className="font-headline font-bold text-sm">Refine your search</p>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div>
         <Label htmlFor="tags_name_eq" className="block mb-1">
           Tags
         </Label>
@@ -51,7 +51,7 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         </Select>
       </div>
 
-      <div className="md:w-5/12">
+      <div>
         <Label htmlFor="duration_eq" className="block mb-1">
           Duration
         </Label>
@@ -65,7 +65,7 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         />
       </div>
 
-      <div className="md:w-5/12">
+      <div>
         <Label htmlFor="user_level_eq" className="block mb-1">
           User level
         </Label>
@@ -81,7 +81,7 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         </Select>
       </div>
 
-      <div className="md:w-5/12">
+      <div>
         <Label htmlFor="user_language_eq" className="block mb-1">
           User language
         </Label>
@@ -97,7 +97,7 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         </Select>
       </div>
 
-      <div className="md:w-5/12">
+      <div>
         <Label className="block mb-1">Session starts from</Label>
         <DatePicker
           value={form.periods_start_at_gteq}
@@ -106,7 +106,7 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         />
       </div>
 
-      <div className="md:w-5/12">
+      <div>
         <Label className="block mb-1">Session starts before</Label>
         <DatePicker
           value={form.periods_start_at_lteq}
@@ -115,7 +115,9 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
         />
       </div>
 
-      <div className="md:w-full flex justify-center mt-6">
+      </div>
+
+      <div className="flex justify-end">
         <Button type="submit" size="lg">
           Search
         </Button>

--- a/app/javascript/components/LandingNav.jsx
+++ b/app/javascript/components/LandingNav.jsx
@@ -12,9 +12,9 @@ export default function LandingNav({ user }) {
       <div className="flex flex-col max-w-screen-xl py-2 mx-auto md:items-center md:justify-between md:flex-row md:px-6 lg:px-8">
         <div className="flex items-center justify-between lg:justify-start">
           <div className="flex items-center justify-center space-x-2">
-            <Link href="/" className="flex flex-col justify-center items-center">
-              <img src={logoImage} alt="logo" className="w-fit h-8 md:h-12" />
-              <span className="text-xl font-bold">pairin</span>
+            <Link href="/" className="flex items-center gap-2">
+              <img src={logoImage} alt="logo" className="h-8 w-8" />
+              <span className="font-display text-xl font-extrabold tracking-tight">pairin</span>
             </Link>
           </div>
 

--- a/app/javascript/components/MainNav.jsx
+++ b/app/javascript/components/MainNav.jsx
@@ -1,142 +1,198 @@
 import { Link } from "@inertiajs/react";
+import { useEffect, useState } from "react";
+import {
+  Search,
+  ClipboardList,
+  FilePlus2,
+  Inbox,
+  Send,
+  Rss,
+  CalendarClock,
+  ChevronDown,
+  LogOut,
+  Menu,
+  X,
+} from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import logoImg from "@/assets/images/logo.svg";
-import hamburgerImg from "@/assets/images/hamburger.svg";
 
-export default function MainNav({ currentUser, currentPath }) {
-  const cleanPath = currentPath.split('?')[0];
+const NAV_ITEMS = [
+  { href: "/pair_requests", label: "Search", icon: Search },
+  { href: "/activities", label: "Feed", icon: Rss },
+  { href: "/sessions", label: "Sessions", icon: CalendarClock },
+];
+
+const PAIR_REQUEST_SUBMENU = [
+  { href: "/users/pair_requests/new", label: "New", icon: FilePlus2 },
+  { href: "/users/pair_requests", label: "Opened", icon: Inbox },
+  { href: "/users/offers", label: "Applied", icon: Send },
+];
+
+function NavLink({ href, label, icon: Icon, active, small = false, onClick }) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className={`flex items-center gap-3 rounded-xl border-2 font-headline font-bold transition-all ${
+        small ? "px-3 py-2 text-sm" : "px-3 py-2.5 text-sm"
+      } ${
+        active
+          ? "border-black bg-purple text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
+          : "border-transparent text-black hover:border-black hover:bg-yellow-50 hover:translate-x-[1px] hover:translate-y-[1px]"
+      }`}
+    >
+      {Icon && <Icon className="h-[18px] w-[18px] shrink-0" strokeWidth={2.25} />}
+      <span className="truncate">{label}</span>
+    </Link>
+  );
+}
+
+function NavContent({ currentPath, currentUser, onNavigate }) {
+  const cleanPath = currentPath.split("?")[0];
   const isActive = (path) => cleanPath === path;
-
-  const isPairRequestSubmenuActive = () => {
-    return ['/users/pair_requests/new', '/users/pair_requests', '/users/offers'].includes(cleanPath);
-  };
-
-  const isAccountActive = () => cleanPath === `/profiles/${currentUser.id}`;
-
-  const getLinkClasses = (path, isSubmenu = false) => {
-    const baseClasses = "h-16 flex justify-center items-center cursor-pointer transition-all hover:translate-x-[3px] hover:translate-y-[3px]";
-    const active = path ? isActive(path) : isPairRequestSubmenuActive();
-    const activeClasses = active
-      ? "bg-main text-main-foreground active"
-      : isSubmenu ? "hover:bg-orange bg-secondary-background" : "hover:bg-orange data-[state=open]:bg-main data-[state=open]:text-main-foreground";
-      
-    return `${baseClasses} ${activeClasses}`;
-  };
+  const isPairRequestSubmenuActive = () => PAIR_REQUEST_SUBMENU.some((item) => item.href === cleanPath);
+  const isProfileActive = () => cleanPath === `/profiles/${currentUser.id}`;
 
   return (
     <>
-      {/* Desktop */}
-      <aside className="hidden md:flex flex-col fixed h-screen w-2/12 font-sans bg-yellow-50 border-r-4 border-black border-dashed overflow-x-hidden z-40">
-        <div className="flex-1 overflow-y-auto overflow-x-hidden">
-          <div className="h-16 flex justify-center items-center border-b-4 border-black">
-            <img src={logoImg} className="w-12 h-12" alt="Logo" />
-          </div>
+      <div className="flex items-center gap-2 border-b-2 border-black px-5 py-5">
+        <img src={logoImg} className="h-8 w-8" alt="Pairin" />
+        <span className="font-display text-xl font-extrabold tracking-tight">pairin</span>
+      </div>
 
-          <Link href="/pair_requests" className={`${getLinkClasses('/pair_requests')} border-b-4 border-black`}>
-            Search
-          </Link>
+      <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <div className="flex flex-col gap-1">
+          <NavLink {...NAV_ITEMS[0]} active={isActive(NAV_ITEMS[0].href)} onClick={onNavigate} />
 
           <Collapsible defaultOpen={isPairRequestSubmenuActive()}>
             <CollapsibleTrigger asChild>
-              <div className={`${getLinkClasses(null)} border-b-4 border-black font-bold`}>
-                Pair Requests
-              </div>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <Link href="/users/pair_requests/new" className={`${getLinkClasses('/users/pair_requests/new', true)} border-b-2 border-black`}>
-                New
-              </Link>
-              <Link href="/users/pair_requests" className={`${getLinkClasses('/users/pair_requests', true)} border-b-2 border-black`}>
-                Opened
-              </Link>
-              <Link href="/users/offers" className={`${getLinkClasses('/users/offers', true)} border-b-2 border-black`}>
-                Applied
-              </Link>
-            </CollapsibleContent>
-          </Collapsible>
-
-          <Link href="/activities" className={`${getLinkClasses('/activities')} border-b-4 border-black`}>
-            Feed
-          </Link>
-
-          <Link href="/sessions" className={`${getLinkClasses('/sessions')} border-b-4 border-black`}>
-            Sessions
-          </Link>
-        </div>
-        <div className="mt-auto border-t-4 border-black bg-yellow-50">
-          <Collapsible>
-            <CollapsibleContent>
-              <Link
-                href={`/profiles/${currentUser.id}`}
-                className={`border-b-2 border-black h-16 flex justify-center items-center transition-all ${isAccountActive() ? 'bg-main text-main-foreground' : 'bg-secondary-background hover:bg-orange'}`}
+              <button
+                type="button"
+                className={`group flex w-full items-center gap-3 rounded-xl border-2 px-3 py-2.5 font-headline font-bold text-sm transition-all ${
+                  isPairRequestSubmenuActive()
+                    ? "border-black bg-purple/10 text-purple"
+                    : "border-transparent text-black hover:border-black hover:bg-yellow-50 hover:translate-x-[1px] hover:translate-y-[1px]"
+                }`}
               >
-                Profile
-              </Link>
-              <Link
-                href="/users/sign_out"
-                method="delete"
-                as="button"
-                className="w-full border-b-2 border-black h-16 flex justify-center items-center bg-secondary-background hover:bg-orange transition-all"
-              >
-                Log out
-              </Link>
-            </CollapsibleContent>
-            <CollapsibleTrigger asChild>
-              <div className={`w-full h-16 flex justify-center items-center cursor-pointer transition-all font-bold ${isAccountActive() ? 'bg-main text-main-foreground' : 'hover:bg-orange data-[state=open]:bg-main data-[state=open]:text-main-foreground'}`}>
-                Account
-              </div>
-            </CollapsibleTrigger>
-          </Collapsible>
-        </div>
-      </aside>
-
-      {/* Mobile */}
-      <div className="md:hidden sticky top-0 z-50 w-full bg-yellow-50 border-b-4 border-black h-16">
-        <div className="relative h-full flex items-center px-4">
-          <img src={logoImg} className="w-10 h-10" alt="Logo" />
-          
-          <Collapsible>
-            <CollapsibleTrigger asChild>
-              <button type="button" className="absolute top-1 right-2 p-1">
-                <img src={hamburgerImg} className="w-8 h-8" alt="Menu" />
+                <ClipboardList className="h-[18px] w-[18px] shrink-0" strokeWidth={2.25} />
+                <span className="flex-1 text-left truncate">Pair Requests</span>
+                <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
               </button>
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div className="absolute top-[60px] left-[-4px] w-[calc(100%+8px)] bg-yellow-50 border-b-4 border-black flex flex-col shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-                <Link href="/pair_requests" className={`${getLinkClasses('/pair_requests')} border-t-4 border-black`}>
-                  Search
-                </Link>
-
-                <Collapsible defaultOpen={isPairRequestSubmenuActive()}>
-                  <CollapsibleTrigger asChild>
-                    <div className={`${getLinkClasses(null)} border-t-4 border-black font-bold`}>
-                      Pair Requests
-                    </div>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <Link href="/users/pair_requests/new" className={`${getLinkClasses('/users/pair_requests/new', true)} border-t-2 border-black`}>New</Link>
-                    <Link href="/users/pair_requests" className={`${getLinkClasses('/users/pair_requests', true)} border-t-2 border-black`}>Opened</Link>
-                    <Link href="/users/offers" className={`${getLinkClasses('/users/offers', true)} border-t-2 border-black`}>Applied</Link>
-                  </CollapsibleContent>
-                </Collapsible>
-
-                <Link href="/activities" className={`${getLinkClasses('/activities')} border-t-4 border-black`}>Feed</Link>
-                <Link href="/sessions" className={`${getLinkClasses('/sessions')} border-t-4 border-black`}>Sessions</Link>
-
-                <Collapsible>
-                  <CollapsibleTrigger asChild>
-                    <div className={`border-t-4 border-black h-16 flex justify-center items-center cursor-pointer font-bold ${isAccountActive() ? 'bg-main text-main-foreground' : 'hover:bg-orange data-[state=open]:bg-main data-[state=open]:text-main-foreground'}`}>
-                      Account
-                    </div>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <Link href={`/profiles/${currentUser.id}`} className={`border-t-2 border-black h-16 flex justify-center items-center transition-all ${isAccountActive() ? 'bg-main text-main-foreground' : 'bg-secondary-background hover:bg-orange'}`}>Profile</Link>
-                    <Link href="/users/sign_out" method="delete" as="button" className="w-full border-t-2 border-black h-16 flex justify-center items-center bg-secondary-background hover:bg-orange">Log out</Link>
-                  </CollapsibleContent>
-                </Collapsible>
+              <div className="relative mt-1 ml-5 flex flex-col gap-1 border-l-2 border-black/15 pl-4">
+                {PAIR_REQUEST_SUBMENU.map((item) => (
+                  <NavLink key={item.href} {...item} active={isActive(item.href)} small onClick={onNavigate} />
+                ))}
               </div>
             </CollapsibleContent>
           </Collapsible>
+
+          <NavLink {...NAV_ITEMS[1]} active={isActive(NAV_ITEMS[1].href)} onClick={onNavigate} />
+          <NavLink {...NAV_ITEMS[2]} active={isActive(NAV_ITEMS[2].href)} onClick={onNavigate} />
+        </div>
+      </nav>
+
+      <div className="border-t-2 border-black p-3">
+        <Link
+          href={`/profiles/${currentUser.id}`}
+          onClick={onNavigate}
+          className={`flex items-center gap-3 rounded-xl border-2 px-3 py-2.5 transition-all ${
+            isProfileActive()
+              ? "border-black bg-purple text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
+              : "border-transparent hover:border-black hover:bg-yellow-50 hover:translate-x-[1px] hover:translate-y-[1px]"
+          }`}
+        >
+          <Avatar className="h-9 w-9 shrink-0 border-2 border-black">
+            <AvatarImage src={currentUser.image_url} alt={currentUser.name} />
+            <AvatarFallback className="bg-orange text-white font-display font-bold">
+              {currentUser.name?.[0]}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-headline font-bold text-sm leading-tight">{currentUser.name || "Your profile"}</p>
+            <span className={`text-xs ${isProfileActive() ? "text-white/70" : "text-black/50"}`}>View profile</span>
+          </div>
+        </Link>
+
+        <Link
+          href="/users/sign_out"
+          method="delete"
+          as="button"
+          onClick={onNavigate}
+          className="mt-1 flex w-full items-center gap-3 rounded-xl border-2 border-transparent px-3 py-2 font-headline font-bold text-sm text-black/60 transition-all hover:border-black hover:bg-red/10 hover:text-red"
+        >
+          <LogOut className="h-[18px] w-[18px] shrink-0" strokeWidth={2.25} />
+          Log out
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default function MainNav({ currentUser, currentPath }) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKeyDown = (e) => e.key === "Escape" && setDrawerOpen(false);
+    document.addEventListener("keydown", onKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [drawerOpen]);
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:fixed md:inset-y-0 md:left-0 md:z-40 md:flex md:w-64 md:flex-col md:border-r-2 md:border-black md:bg-white">
+        <NavContent currentPath={currentPath} currentUser={currentUser} />
+      </aside>
+
+      {/* Mobile top bar */}
+      <div className="sticky top-0 z-30 flex h-16 w-full items-center justify-between border-b-2 border-black bg-white px-4 md:hidden">
+        <Link href="/pair_requests" className="flex items-center gap-2">
+          <img src={logoImg} className="h-8 w-8" alt="Pairin" />
+          <span className="font-display text-lg font-extrabold tracking-tight">pairin</span>
+        </Link>
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          aria-label="Open menu"
+          className="flex h-10 w-10 items-center justify-center rounded-xl border-2 border-black bg-white transition-all hover:translate-x-[1px] hover:translate-y-[1px] active:shadow-none"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Mobile drawer */}
+      <div
+        className={`fixed inset-0 z-50 md:hidden ${drawerOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+        aria-hidden={!drawerOpen}
+      >
+        <div
+          onClick={() => setDrawerOpen(false)}
+          className={`absolute inset-0 bg-black/50 transition-opacity duration-300 ${
+            drawerOpen ? "opacity-100" : "opacity-0"
+          }`}
+        />
+        <div
+          className={`absolute inset-y-0 left-0 flex w-72 max-w-[80%] flex-col border-r-2 border-black bg-white shadow-[8px_0px_0px_0px_rgba(0,0,0,1)] transition-transform duration-300 ease-in-out ${
+            drawerOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => setDrawerOpen(false)}
+            aria-label="Close menu"
+            className="absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-xl border-2 border-black bg-white"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <NavContent currentPath={currentPath} currentUser={currentUser} onNavigate={() => setDrawerOpen(false)} />
         </div>
       </div>
     </>

--- a/app/javascript/components/PageHeader.jsx
+++ b/app/javascript/components/PageHeader.jsx
@@ -1,0 +1,14 @@
+export default function PageHeader({ eyebrow, title, description, action }) {
+  return (
+    <div className="mb-8 mt-8 flex flex-col gap-5 md:mt-10 md:mb-10 md:flex-row md:items-end md:justify-between">
+      <div>
+        {eyebrow && (
+          <span className="mb-2 block text-xs font-bold uppercase tracking-widest text-purple">{eyebrow}</span>
+        )}
+        <h1 className="text-3xl leading-tight md:text-4xl">{title}</h1>
+        {description && <p className="mt-2 max-w-lg text-black/50">{description}</p>}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}

--- a/app/javascript/layouts/AppLayout.jsx
+++ b/app/javascript/layouts/AppLayout.jsx
@@ -22,10 +22,10 @@ export default function AppLayout({ children }) {
   }, []);
 
   return (
-    <main className='relative bg-yellow-50 min-h-screen pt-8 md:pt-0'>
+    <main className='relative bg-yellow-50 min-h-screen'>
       <Toaster position="top-center" />
       <MainNav currentUser={currentUser} currentPath={url} />
-      <article className="md:ml-[16.666667%] min-h-screen">{children}</article>
+      <article className="min-h-screen md:ml-64">{children}</article>
     </main>
   );
 }

--- a/app/javascript/pages/Activities.jsx
+++ b/app/javascript/pages/Activities.jsx
@@ -1,45 +1,51 @@
 import { Head, Link } from "@inertiajs/react"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Bell, Sparkles } from "lucide-react"
+import PageHeader from "@/components/PageHeader"
+import EmptyState from "@/components/EmptyState"
 
 export default function Activities({ activities }) {
   return (
-    <div className="flex flex-col items-center w-full px-4">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Activity Feed"/>
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center justify-center md:justify-start mt-12 pb-8 border-b-4 border-black border-dashed text-center md:text-left">
-          <h3 className="text-4xl md:text-5xl font-bold">Activity Feed</h3>
-        </div>
+      <PageHeader
+        eyebrow="Feed"
+        title="Activity Feed"
+        description="Updates from your requests, applications, and matches, all in one place."
+      />
 
-        <div className="mt-12">
-          {activities.length > 0 ? (
-            activities.map((activity) => (
-              <Card key={activity.id} className="mb-8 bg-white gap-0 py-0">
-                <CardHeader className="border-b-2 border-border bg-main py-4 px-2 rounded-t-base">
-                  <CardTitle>{activity.title}</CardTitle>
-                </CardHeader>
-                <CardContent className="px-2 py-4">
-                  <p>{activity.content}</p>
-                </CardContent>
-              </Card>
-            ))
-          ) : (
-            <div className="text-center p-8 border-2 border-black border-dashed rounded-md bg-white">
-              <p className="mb-4">Nothing new from community for you!</p>
-              <p>
-                But we know how to help you, you can start by{" "}
-                <Link href="/users/pair_requests/new" className="font-bold underline text-purple">
-                  creating a pair request
-                </Link>{" "}
-                or maybe{" "}
-                <Link href="/pair_requests" className="font-bold underline text-purple">
-                  sending an offer
-                </Link>
-              </p>
+      {activities.length > 0 ? (
+        <div className="flex flex-col gap-5">
+          {activities.map((activity) => (
+            <div
+              key={activity.id}
+              className="flex gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border-2 border-black bg-purple/10">
+                <Bell className="h-5 w-5 text-purple" strokeWidth={2.25} />
+              </div>
+              <div className="min-w-0">
+                <p className="font-bold">{activity.title}</p>
+                <p className="mt-1 text-black/60">{activity.content}</p>
+              </div>
             </div>
-          )}
+          ))}
         </div>
-      </div>
+      ) : (
+        <EmptyState icon={Sparkles} title="Nothing new from the community yet">
+          <p className="mt-1 text-black/50">
+            Start by{" "}
+            <Link href="/users/pair_requests/new" className="font-bold text-purple underline">
+              creating a pair request
+            </Link>{" "}
+            or{" "}
+            <Link href="/pair_requests" className="font-bold text-purple underline">
+              sending an offer
+            </Link>
+            .
+          </p>
+        </EmptyState>
+      )}
     </div>
   )
 }

--- a/app/javascript/pages/PairRequests/Card.jsx
+++ b/app/javascript/pages/PairRequests/Card.jsx
@@ -1,10 +1,12 @@
 import { Link } from "@inertiajs/react";
+import { ArrowRight } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import ExpandableText from "@/components/ExpandableText";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+
+const TAG_COLORS = ["bg-purple text-white", "bg-orange text-white", "bg-green text-black"];
 
 export default function PairRequestCard({ pairRequest, currentUserId }) {
   const alreadyOffered = pairRequest.offers
@@ -12,72 +14,59 @@ export default function PairRequestCard({ pairRequest, currentUserId }) {
     .includes(currentUserId);
 
   return (
-    <Card className="mb-12 bg-white gap-0 py-0 pb-4">
-      <CardHeader className="border-b-2 border-border bg-main py-4 px-2 rounded-t-base">
-        <CardTitle className="text-xl">{pairRequest.subject}</CardTitle>
-      </CardHeader>
+    <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-y-0.5 hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] md:p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <h3 className="text-xl">{pairRequest.subject}</h3>
 
-      <CardContent className="md:flex max-h-fit px-2 py-4">
-        <div className="w-full md:w-7/12">
-          <ExpandableText>{pairRequest.description}</ExpandableText>
-        </div>
-
-        <div className="w-full mt-4 md:mt-0 md:w-5/12">
+        <div className="flex flex-wrap gap-2 md:flex-col md:items-end">
           {pairRequest.periods.map((period) => (
-            <div
-              key={period.id}
-              className="w-full flex md:items-center md:justify-end gap-x-1 mt-1"
-            >
-              <Badge variant="neutral" className="text-sm">
+            <div key={period.id} className="flex items-center gap-1.5">
+              <Badge variant="neutral" className="rounded-full text-xs">
                 {formatShort(period.start_at)}
               </Badge>
-              <span className="block font-bold">:</span>
-              <Badge variant="neutral" className="text-sm">
+              <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
+              <Badge variant="neutral" className="rounded-full text-xs">
                 {formatShort(period.end_at)}
               </Badge>
             </div>
           ))}
         </div>
-      </CardContent>
+      </div>
 
-      <div className="flex w-full overflow-x-scroll justify-start space-x-2 py-2 px-2 mb-6">
-        {pairRequest.tags.map((tag) => (
-          <Badge
-            key={tag.id}
-            className="bg-orange shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none 2xl:text-sm"
-          >
+      <ExpandableText className="mt-3 leading-relaxed text-black/60">{pairRequest.description}</ExpandableText>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {pairRequest.tags.map((tag, i) => (
+          <Badge key={tag.id} className={`rounded-full border-black ${TAG_COLORS[i % TAG_COLORS.length]}`}>
             {tag.name}
           </Badge>
         ))}
       </div>
 
-      <CardFooter className="px-4 flex-col md:flex-row items-start md:items-center">
-        <div className="md:w-1/2 flex items-center gap-x-2">
-          <Avatar className="w-12 h-12">
+      <div className="mt-5 flex flex-col gap-4 border-t-2 border-black/10 pt-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-11 w-11 border-2 border-black">
             <AvatarImage src={pairRequest.user.image_url} alt={pairRequest.user.name} />
-            <AvatarFallback>{pairRequest.user.name?.[0]}</AvatarFallback>
+            <AvatarFallback className="bg-orange text-white font-bold">{pairRequest.user.name?.[0]}</AvatarFallback>
           </Avatar>
-
           <div>
-            <p>{pairRequest.user.name}</p>
-            <span className="text-sm">
+            <p className="font-bold text-sm">{pairRequest.user.name}</p>
+            <span className="text-xs text-black/50">
               {pairRequest.user.profession}
-              <span className="text-xl font-bold">.</span>
+              {pairRequest.user.profession && pairRequest.user.level_titleized && " · "}
               {pairRequest.user.level_titleized}
             </span>
           </div>
         </div>
 
-        <div className="md:w-1/2 mt-4 md:mt-0 md:flex md:justify-end">
-          {alreadyOffered ? (
-            <p>You have already sent an offer</p>
-          ) : (
-            <Button asChild className="md:w-1/2">
-              <Link href={`/pair_requests/${pairRequest.id}/offers/new`}>Apply</Link>
-            </Button>
-          )}
-        </div>
-      </CardFooter>
-    </Card>
+        {alreadyOffered ? (
+          <span className="text-sm font-bold italic text-black/40">Application sent</span>
+        ) : (
+          <Button asChild>
+            <Link href={`/pair_requests/${pairRequest.id}/offers/new`}>Apply</Link>
+          </Button>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/javascript/pages/PairRequests/Card.jsx
+++ b/app/javascript/pages/PairRequests/Card.jsx
@@ -60,7 +60,7 @@ export default function PairRequestCard({ pairRequest, currentUserId }) {
         </div>
 
         {alreadyOffered ? (
-          <span className="text-sm font-bold italic text-black/40">Application sent</span>
+          <span className="text-sm font-bold italic text-black/40">You have already sent an offer</span>
         ) : (
           <Button asChild>
             <Link href={`/pair_requests/${pairRequest.id}/offers/new`}>Apply</Link>

--- a/app/javascript/pages/PairRequests/Index.jsx
+++ b/app/javascript/pages/PairRequests/Index.jsx
@@ -1,8 +1,11 @@
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
 import FilterForm from "@/components/FilterForm";
 import Card from "./Card";
 import { Head, router, usePage, InfiniteScroll } from "@inertiajs/react";
-import preferencesImg from "@/assets/images/preferences.svg";
+import { SlidersHorizontal, SearchX } from "lucide-react";
 
 export default function Index({ pairRequests, filterOptions, filters }) {
   const { auth } = usePage().props;
@@ -11,26 +14,23 @@ export default function Index({ pairRequests, filterOptions, filters }) {
   const { tags, userLevels, languages } = filterOptions;
 
   return (
-    <>
-      <div className="flex flex-col items-center w-full">
-        <Head title="Pair Programming Requests" />
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
+      <Head title="Pair Programming Requests" />
 
-        <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-          <div className="flex w-full items-center mt-12 pb-8 border-b-4 border-black border-dashed text-center">
-            <h3 className="text-5xl font-bold">Pair Programming Requests</h3>
-          </div>
-
-          <div className="mt-12">
-            <Collapsible>
-              <CollapsibleTrigger asChild>
-                <button className="relative group overflow-hidden items-center w-full flex justify-end mb-2 pr-4 md:pr-0">
-                  <span className="absolute block font-bold top-0 -right-[60px] transition ease-in-out duration-500 group-hover:-translate-x-24">
-                    Filter
-                  </span>
-                  <img src={preferencesImg} className="z-10 bg-yellow-50" />
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
+      <PageHeader
+        eyebrow="Search"
+        title="Pair Programming Requests"
+        description="Browse open requests from the community and find a partner to build or learn with."
+        action={
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <Button variant="neutral" size="sm">
+                <SlidersHorizontal className="h-4 w-4" />
+                Filters
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="w-full">
+              <div className="fixed inset-x-4 top-24 z-40 rounded-2xl border-2 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-3 md:w-[560px]">
                 <FilterForm
                   tags={tags}
                   userLevels={userLevels}
@@ -40,33 +40,37 @@ export default function Index({ pairRequests, filterOptions, filters }) {
                     router.get("/pair_requests", { q });
                   }}
                 />
-              </CollapsibleContent>
-            </Collapsible>
-          </div>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        }
+      />
 
-          <div className="mt-12 mb-12">
-            <InfiniteScroll
-              data="pairRequests"
-              loading={() => (
-                <div className="flex justify-center py-8">
-                  <div className="text-lg font-bold">Loading more...</div>
-                </div>
-              )}
-              next={({ hasMore }) =>
-                !hasMore && pairRequests.length > 0 ? (
-                  <div className="flex justify-center py-8">
-                    <div className="text-lg font-bold text-gray-500">No more requests</div>
-                  </div>
-                ) : null
-              }
-            >
-              {pairRequests.map((req) => (
-                <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
-              ))}
-            </InfiniteScroll>
-          </div>
-        </div>
+      <div className="relative flex flex-col gap-6">
+        <InfiniteScroll
+          data="pairRequests"
+          loading={() => (
+            <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
+          )}
+          next={({ hasMore }) =>
+            !hasMore && pairRequests.length > 0 ? (
+              <div className="flex justify-center py-8 text-black/40">No more requests</div>
+            ) : null
+          }
+        >
+          {pairRequests.map((req) => (
+            <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
+          ))}
+        </InfiniteScroll>
+
+        {pairRequests.length === 0 && (
+          <EmptyState
+            icon={SearchX}
+            title="No requests match your search"
+            description="Try widening your filters or check back soon — new requests come in all the time."
+          />
+        )}
       </div>
-    </>
+    </div>
   );
 }

--- a/app/javascript/pages/PairRequests/Offers/Card.jsx
+++ b/app/javascript/pages/PairRequests/Offers/Card.jsx
@@ -1,10 +1,10 @@
 import { router } from '@inertiajs/react';
+import { ArrowRight, CheckCircle2 } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import ExpandableText from "@/components/ExpandableText";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardHeader, CardContent, CardFooter } from "@/components/ui/card";
 
 export default function OfferCard({ offer, pairRequestId }) {
   const handleAccept = () => {
@@ -12,47 +12,42 @@ export default function OfferCard({ offer, pairRequestId }) {
   };
 
   return (
-    <Card className="relative mb-12 bg-white gap-0 py-0 pb-4">
-      {offer.should_overlay && (
-        <div className="absolute w-full h-full bg-black opacity-20 rounded-base z-10" />
-      )}
-
-      <CardHeader className="flex flex-row items-center gap-x-2 px-4 pt-4 pb-0">
-        <Avatar className="w-12 h-12 shrink-0">
+    <div
+      className={`relative mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6 ${
+        offer.should_overlay ? "opacity-50" : ""
+      }`}
+    >
+      <div className="flex flex-wrap items-center gap-3">
+        <Avatar className="h-11 w-11 shrink-0 border-2 border-black">
           <AvatarImage src={offer.offerer.image_url} alt={offer.offerer.name} />
-          <AvatarFallback>{offer.offerer.name?.[0]}</AvatarFallback>
+          <AvatarFallback className="bg-orange text-white font-bold">{offer.offerer.name?.[0]}</AvatarFallback>
         </Avatar>
-        <p>{offer.offerer.name}</p>
+        <p className="font-bold">{offer.offerer.name}</p>
         {offer.status === "ACCEPTED" && (
-          <Badge className="ml-auto bg-green-400 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
-            ACCEPTED
+          <Badge className="ml-auto rounded-full border-black bg-green text-black">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Accepted
           </Badge>
         )}
-      </CardHeader>
+      </div>
 
-      <CardContent className="px-2 py-4">
-        <ExpandableText className="whitespace-pre-wrap">{offer.message}</ExpandableText>
-      </CardContent>
+      <ExpandableText className="mt-4 whitespace-pre-wrap leading-relaxed text-black/60">{offer.message}</ExpandableText>
 
-      <CardFooter className="px-4 flex-col md:flex-row items-start md:items-center">
-        <div className="md:w-1/2 flex items-center gap-x-2">
-          <Badge variant="neutral">
+      <div className="mt-4 flex flex-col gap-4 border-t-2 border-black/10 pt-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-1.5">
+          <Badge variant="neutral" className="rounded-full text-xs">
             {formatShort(offer.start_at)}
           </Badge>
-          <span className="block font-bold">:</span>
-          <Badge variant="neutral">
+          <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
+          <Badge variant="neutral" className="rounded-full text-xs">
             {formatShort(offer.end_at)}
           </Badge>
         </div>
 
-        <div className="md:w-1/2 md:flex md:justify-end">
-          {offer.show_accept_button && (
-            <div className="flex justify-center mt-6">
-              <Button onClick={handleAccept}>Accept</Button>
-            </div>
-          )}
-        </div>
-      </CardFooter>
-    </Card>
+        {offer.show_accept_button && (
+          <Button onClick={handleAccept}>Accept</Button>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/javascript/pages/PairRequests/Offers/Index.jsx
+++ b/app/javascript/pages/PairRequests/Offers/Index.jsx
@@ -1,31 +1,23 @@
 import { Head } from "@inertiajs/react";
+import { Inbox } from "lucide-react";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
 import Card from './Card';
 
 export default function Index({ offers, pairRequestId }) {
   return (
-    <div className="flex flex-col items-center">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Applications" />
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center mt-12 pb-8 border-b-4 border-black border-dashed">
-          <h3 className="text-5xl font-bold">Applications</h3>
-        </div>
+      <PageHeader eyebrow="Pair Requests" title="Applications" description="Who's applied to pair with you on this request." />
 
-        <div className="mt-12">
-          {offers.length > 0 ? (
-            offers.map((offer) => (
-              <Card key={offer.id} offer={offer} pairRequestId={pairRequestId} />
-            ))
-          ) : (
-            <div className="border-4 border-dashed border-black rounded-md p-12 text-center bg-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-              <p className="text-2xl font-bold italic text-gray-400">
-                No applications yet.
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+      {offers.length > 0 ? (
+        offers.map((offer) => (
+          <Card key={offer.id} offer={offer} pairRequestId={pairRequestId} />
+        ))
+      ) : (
+        <EmptyState icon={Inbox} title="No applications yet" description="Share your request in the feed or hang tight — new applicants show up here." />
+      )}
     </div>
   );
 }
-

--- a/app/javascript/pages/PairRequests/Offers/New.jsx
+++ b/app/javascript/pages/PairRequests/Offers/New.jsx
@@ -1,6 +1,7 @@
 import { Form, Head } from '@inertiajs/react';
 import { formatShort } from "@/helpers/date";
 import { useState } from "react";
+import PageHeader from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -10,53 +11,48 @@ export default function New({ pairRequestId, periods }) {
   const [periodId, setPeriodId] = useState(String(periods[0]?.id || ""));
 
   return (
-    <div className="flex flex-col items-center w-full px-4">
+    <div className="mx-auto w-full max-w-2xl px-4 pb-16 md:px-8">
       <Head title="Send application" />
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center mt-12 pb-8 border-b-4 border-black border-dashed text-center">
-          <h3 className="text-5xl font-bold">Send application</h3>
-        </div>
 
-        <Form method="post" action={`/pair_requests/${pairRequestId}/offers`} className="flex flex-col items-start mt-12">
-          {({ errors, processing }) => (
-            <>
-              <div className="w-full">
-                <Label htmlFor="message" className="block mb-1">Message</Label>
-                <Textarea id="message" name="message" rows="4" className="w-full" />
-                {errors.message && (
-                  <div className="text-red-600 font-bold mt-1">{errors.message}</div>
-                )}
-              </div>
+      <PageHeader eyebrow="Apply" title="Send application" description="Introduce yourself and pick the time slot that works for you." />
 
-              <div className="w-full mt-4">
-                <Label className="block mb-1">Select period</Label>
-                <input type="hidden" name="period_id" value={periodId} />
-                <Select value={periodId} onValueChange={setPeriodId}>
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a period" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {periods.map(period => (
-                      <SelectItem key={period.id} value={String(period.id)}>
-                        {formatShort(period.start_at)} : {formatShort(period.end_at)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {(errors.period || errors.period_id) && (
-                  <div className="text-orange font-bold mt-1">{errors.period || errors.period_id}</div>
-                )}
-              </div>
+      <Form method="post" action={`/pair_requests/${pairRequestId}/offers`} className="flex flex-col items-stretch">
+        {({ errors, processing }) => (
+          <>
+            <div className="w-full">
+              <Label htmlFor="message" className="block mb-1">Message</Label>
+              <Textarea id="message" name="message" rows="4" className="w-full" />
+              {errors.message && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.message}</div>
+              )}
+            </div>
 
-              <div className="w-full flex justify-center mt-12">
-                <Button type="submit" size="lg" disabled={processing}>
-                  {processing ? 'Sending...' : 'Apply'}
-                </Button>
-              </div>
-            </>
-          )}
-        </Form>
-      </div>
+            <div className="w-full mt-4">
+              <Label className="block mb-1">Select period</Label>
+              <input type="hidden" name="period_id" value={periodId} />
+              <Select value={periodId} onValueChange={setPeriodId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a period" />
+                </SelectTrigger>
+                <SelectContent>
+                  {periods.map(period => (
+                    <SelectItem key={period.id} value={String(period.id)}>
+                      {formatShort(period.start_at)} : {formatShort(period.end_at)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {(errors.period || errors.period_id) && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.period || errors.period_id}</div>
+              )}
+            </div>
+
+            <Button type="submit" size="lg" disabled={processing} className="mt-10 self-center">
+              {processing ? 'Sending...' : 'Apply'}
+            </Button>
+          </>
+        )}
+      </Form>
     </div>
   );
 }

--- a/app/javascript/pages/Profile.jsx
+++ b/app/javascript/pages/Profile.jsx
@@ -31,152 +31,155 @@ export default function Profile({ user, countries, languages, levels }) {
   };
 
   return (
-    <div className="flex flex-col items-center w-full px-4">
+    <div className="mx-auto w-full max-w-2xl px-4 pb-16 md:px-8">
       <Head title={`${user.name}'s Profile`} />
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <Form method="patch" action={`/profiles/${user.id}`}>
-          {({ errors, processing, progress }) => (
-            <>
-              <div className="flex flex-col items-center w-full mt-12 pb-8 border-b-4 border-black border-dashed text-center">
-                <h3 className="text-5xl font-bold mb-4">{user.name}</h3>
+      <Form method="patch" action={`/profiles/${user.id}`}>
+        {({ errors, processing, progress }) => (
+          <>
+            <div className="flex flex-col items-center pb-10 pt-10 text-center md:pt-14">
+              <Avatar className="h-28 w-28 rounded-2xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                <AvatarImage src={previewUrl} alt={user.name} className="object-cover" />
+                <AvatarFallback className="rounded-2xl bg-orange text-3xl font-bold text-white">
+                  {user.name?.[0]}
+                </AvatarFallback>
+              </Avatar>
 
-                <Avatar className="w-32 h-32 rounded-xl border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-                  <AvatarImage src={previewUrl} alt={user.name} className="object-contain" />
-                  <AvatarFallback className="rounded-xl text-4xl">{user.name?.[0]}</AvatarFallback>
-                </Avatar>
+              <h1 className="mt-4 text-3xl">{user.name || "Your profile"}</h1>
+              {user.profession && <p className="mt-1 text-black/50">{user.profession}</p>}
 
-                <div className="mt-4">
-                  <Collapsible key={user.image_url}>
-                    <CollapsibleTrigger asChild>
-                      <Button type="button" variant="neutral" size="sm">
-                        Change Avatar
-                      </Button>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                      <div className="mt-4">
-                        <input
-                          type="file"
-                          name="image"
-                          onChange={handleFileChange}
-                          className="w-full rounded-md border-2 border-black p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] bg-white"
-                        />
-                      </div>
-                    </CollapsibleContent>
-                  </Collapsible>
+              <div className="mt-4">
+                <Collapsible key={user.image_url}>
+                  <CollapsibleTrigger asChild>
+                    <Button type="button" variant="neutral" size="sm">
+                      Change Avatar
+                    </Button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="mt-4">
+                      <input
+                        type="file"
+                        name="image"
+                        onChange={handleFileChange}
+                        className="w-full rounded-xl border-2 border-black bg-white p-2 font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+                      />
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-6 border-t-2 border-black/10 pt-8">
+              {progress && (
+                <Progress value={progress.percentage ?? 0} className="w-full" />
+              )}
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <Label className="block mb-1">Name</Label>
+                  <Input name="name" defaultValue={user.name || ""} />
+                  {errors.name && <div className="text-red font-bold mt-1 text-sm">{errors.name}</div>}
+                </div>
+
+                <div>
+                  <Label className="block mb-1">Profession</Label>
+                  <Input name="profession" defaultValue={user.profession || ""} />
                 </div>
               </div>
 
-              <div className="flex flex-col items-center mt-8 pb-20">
-                {progress && (
-                  <Progress value={progress.percentage ?? 0} className="w-full mb-4" />
-                )}
+              <div>
+                <Label className="block mb-1">About</Label>
+                <Textarea name="about" rows="4" defaultValue={user.about || ""} />
+              </div>
 
-                <div className="w-full flex flex-wrap md:flex-nowrap gap-4">
-                  <div className="w-full md:w-1/2 text-left">
-                    <Label className="block mb-1">Name</Label>
-                    <Input name="name" defaultValue={user.name || ""} />
-                    {errors.name && <div className="text-red-500 font-bold mt-1 text-sm">{errors.name}</div>}
-                  </div>
-
-                  <div className="w-full md:w-1/2 text-left">
-                    <Label className="block mb-1">Profession</Label>
-                    <Input name="profession" defaultValue={user.profession || ""} />
-                  </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <Label className="block mb-1">Date of Birth</Label>
+                  <input type="hidden" name="date_of_birth" value={dateOfBirth} />
+                  <DatePicker
+                    value={dateOfBirth}
+                    onChange={setDateOfBirth}
+                    placeholder="Pick your birth date"
+                    captionLayout="dropdown-buttons"
+                    fromYear={currentYear - 100}
+                    toYear={currentYear}
+                    defaultMonth={new Date(1995, 0)}
+                    disabled={(date) => date > new Date()}
+                  />
                 </div>
 
-                <div className="w-full mt-6 text-left">
-                  <Label className="block mb-1">About</Label>
-                  <Textarea name="about" rows="4" defaultValue={user.about || ""} />
+                <div>
+                  <Label className="block mb-1">Programming Since</Label>
+                  <input type="hidden" name="programming_since" value={programmingSince} />
+                  <Select value={programmingSince} onValueChange={setProgrammingSince}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select a year" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {programmingYears.map((year) => (
+                        <SelectItem key={year} value={String(year)}>{year}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <div>
+                  <Label className="block mb-1">Country</Label>
+                  <input type="hidden" name="country" value={country} />
+                  <Select value={country} onValueChange={setCountry}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select a country" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {countries.map(([label, value]) => (
+                        <SelectItem key={value} value={value}>{label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
 
-                <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
-                  <div className="w-full md:w-1/2 text-left">
-                    <Label className="block mb-1">Date of Birth</Label>
-                    <input type="hidden" name="date_of_birth" value={dateOfBirth} />
-                    <DatePicker
-                      value={dateOfBirth}
-                      onChange={setDateOfBirth}
-                      placeholder="Pick your birth date"
-                      captionLayout="dropdown-buttons"
-                      fromYear={currentYear - 100}
-                      toYear={currentYear}
-                      defaultMonth={new Date(1995, 0)}
-                      disabled={(date) => date > new Date()}
-                    />
-                  </div>
-
-                  <div className="w-full md:w-1/2 text-left">
-                    <Label className="block mb-1">Programming Since</Label>
-                    <input type="hidden" name="programming_since" value={programmingSince} />
-                    <Select value={programmingSince} onValueChange={setProgrammingSince}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a year" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {programmingYears.map((year) => (
-                          <SelectItem key={year} value={String(year)}>{year}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
+                <div>
+                  <Label className="block mb-1">Language</Label>
+                  <input type="hidden" name="language" value={language} />
+                  <Select value={language} onValueChange={setLanguage}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select a language" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {languages.map(([label, value]) => (
+                        <SelectItem key={value} value={value}>{label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
 
-                <div className="w-full flex flex-wrap md:flex-nowrap gap-4 mt-6">
-                  <div className="w-full md:w-1/3 text-left">
-                    <Label className="block mb-1">Country</Label>
-                    <input type="hidden" name="country" value={country} />
-                    <Select value={country} onValueChange={setCountry}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a country" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {countries.map(([label, value]) => (
-                          <SelectItem key={value} value={value}>{label}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="w-full md:w-1/3 text-left">
-                    <Label className="block mb-1">Language</Label>
-                    <input type="hidden" name="language" value={language} />
-                    <Select value={language} onValueChange={setLanguage}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a language" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {languages.map(([label, value]) => (
-                          <SelectItem key={value} value={value}>{label}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="w-full md:w-1/3 text-left">
-                    <Label className="block mb-1">Level</Label>
-                    <input type="hidden" name="level" value={level} />
-                    <Select value={level} onValueChange={setLevel}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a level" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {levels.map(([label, value]) => (
-                          <SelectItem key={value} value={value}>{label}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
+                <div>
+                  <Label className="block mb-1">Level</Label>
+                  <input type="hidden" name="level" value={level} />
+                  <Select value={level} onValueChange={setLevel}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select a level" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {levels.map(([label, value]) => (
+                        <SelectItem key={value} value={value}>{label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
+              </div>
 
-                <Button type="submit" size="lg" disabled={processing} className="mt-16">
+              <div className="flex justify-center pt-6">
+                <Button type="submit" size="lg" disabled={processing}>
                   {processing ? "Saving..." : "Save Changes"}
                 </Button>
               </div>
-            </>
-          )}
-        </Form>
-      </div>
+            </div>
+          </>
+        )}
+      </Form>
     </div>
   );
 }

--- a/app/javascript/pages/Sessions/Card.jsx
+++ b/app/javascript/pages/Sessions/Card.jsx
@@ -10,7 +10,9 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 export default function SessionCard({ session }) {
   return (
     <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <h3 className="text-xl">{session.subject}</h3>
+
+      <div className="mt-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
           <Avatar className="h-11 w-11 border-2 border-black">
             <AvatarImage src={session.other_participant.image_url} alt={session.other_participant.name} />

--- a/app/javascript/pages/Sessions/Card.jsx
+++ b/app/javascript/pages/Sessions/Card.jsx
@@ -1,59 +1,53 @@
 import { Form } from "@inertiajs/react";
+import { ArrowRight } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 
 export default function SessionCard({ session }) {
   return (
-    <Card className="mb-12 bg-white gap-0 py-0 pb-4">
-      <CardHeader className="border-b-2 border-border bg-main py-4 px-2 rounded-t-base">
-        <CardTitle className="text-xl">{session.subject}</CardTitle>
-      </CardHeader>
-
-      <CardContent className="md:flex items-center max-h-fit px-2 py-4">
-        <div className="md:w-1/2 flex flex-col md:flex-row items-center md:items-start gap-y-2 md:gap-x-2 text-center md:text-left">
-          <Avatar className="w-12 h-12">
+    <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-11 w-11 border-2 border-black">
             <AvatarImage src={session.other_participant.image_url} alt={session.other_participant.name} />
-            <AvatarFallback>{session.other_participant.name?.[0]}</AvatarFallback>
+            <AvatarFallback className="bg-orange text-white font-bold">{session.other_participant.name?.[0]}</AvatarFallback>
           </Avatar>
           <div>
-            <p className="font-bold">{session.other_participant.name}</p>
-            <span className="text-sm">
+            <p className="font-bold text-sm">{session.other_participant.name}</p>
+            <span className="text-xs text-black/50">
               {session.other_participant.profession}
-              <span className="text-gray-400 font-black"> &bull; </span>
+              {session.other_participant.profession && " · "}
               {session.other_participant.level}
             </span>
           </div>
         </div>
 
-        <div className="w-full mt-6 md:mt-0 md:w-1/2">
-          <div className="w-full flex items-center justify-center md:justify-end gap-x-1">
-            <Badge variant="neutral" className="text-sm px-3">
-              {formatShort(session.start_at)}
-            </Badge>
-            <span className="block font-bold">:</span>
-            <Badge variant="neutral" className="text-sm px-3">
-              {formatShort(session.end_at)}
-            </Badge>
-          </div>
+        <div className="flex items-center gap-1.5">
+          <Badge variant="neutral" className="rounded-full text-xs">
+            {formatShort(session.start_at)}
+          </Badge>
+          <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
+          <Badge variant="neutral" className="rounded-full text-xs">
+            {formatShort(session.end_at)}
+          </Badge>
         </div>
-      </CardContent>
+      </div>
 
-      <CardFooter className="w-full flex justify-center px-2">
+      <div className="mt-5 border-t-2 border-black/10 pt-4">
         {session.is_holder ? (
-          <Form method="patch" action={`/sessions/${session.id}`} className="flex flex-col md:flex-row w-full gap-y-4 md:gap-x-2 items-center md:items-end justify-between">
+          <Form method="patch" action={`/sessions/${session.id}`} className="flex flex-col items-stretch gap-2 md:flex-row md:items-end">
             {({ processing }) => (
               <>
-                <div className="flex flex-col justify-end w-full">
+                <div className="flex flex-1 flex-col">
                   <Label htmlFor="session_call_link" className="mb-1">Call link</Label>
                   <Input id="session_call_link" name="call_link" defaultValue={session.call_link || ""} />
                 </div>
 
-                <Button type="submit" disabled={processing} className="w-3/4 md:w-1/4">
+                <Button type="submit" disabled={processing} className="md:w-32">
                   {processing ? "..." : "Add"}
                 </Button>
               </>
@@ -61,18 +55,18 @@ export default function SessionCard({ session }) {
           </Form>
         ) : (
           session.call_link ? (
-            <Button asChild className="w-3/4 truncate">
+            <Button asChild className="w-full">
               <a href={session.call_link} rel="noopener noreferrer" target="_blank">
                 Join Call
               </a>
             </Button>
           ) : (
-            <p className="font-semibold text-gray-600">
+            <p className="text-sm font-semibold text-black/50">
               Waiting for {session.holder_name} to provide the link
             </p>
           )
         )}
-      </CardFooter>
-    </Card>
+      </div>
+    </div>
   )
 }

--- a/app/javascript/pages/Sessions/Index.jsx
+++ b/app/javascript/pages/Sessions/Index.jsx
@@ -1,26 +1,23 @@
 import { Head } from "@inertiajs/react";
+import { CalendarClock } from "lucide-react";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
 import Card from "./Card";
 
 export default function Index( {sessions} ) {
   return (
-    <div className="flex flex-col items-center px-4">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Your Sessions" />
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center justify-center md:justify-start mt-12 pb-8 border-b-4 border-black border-dashed text-center md:text-left">
-          <h3 className="text-4xl md:text-5xl font-bold">Sessions</h3>
-        </div>
-        <div className="mt-12">
-          {sessions.length > 0 ? (
-            sessions.map((session) => (
-              <Card key={session.id} session={session} />
-            ))
-          ) : (
-            <p className="text-center font-bold text-xl">No upcoming sessions found.</p>
-          )}
-        </div>
-      </div>
+      <PageHeader eyebrow="Sessions" title="Sessions" description="Your upcoming and past pairing sessions." />
+
+      {sessions.length > 0 ? (
+        sessions.map((session) => (
+          <Card key={session.id} session={session} />
+        ))
+      ) : (
+        <EmptyState icon={CalendarClock} title="No upcoming sessions found" description="Once a request is matched, your sessions will show up here." />
+      )}
     </div>
   )
 }
-

--- a/app/javascript/pages/Users/Offers/Card.jsx
+++ b/app/javascript/pages/Users/Offers/Card.jsx
@@ -1,62 +1,58 @@
 import { formatShort } from "@/helpers/date";
+import { ArrowRight } from "lucide-react";
 import ExpandableText from "@/components/ExpandableText";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 
-const StatusBadge = ({ status }) => {
-  const styles = {
-    "ACCEPTED": "bg-green",
-    "ACCEPTED OTHER": "bg-gray-200 text-gray-500",
-    "EXPIRED": "bg-red text-white",
-    "PENDING": "bg-orange"
-  };
-
-  return (
-    <Badge className={styles[status] || 'bg-white'}>
-      {status}
-    </Badge>
-  );
+const STATUS_STYLES = {
+  "ACCEPTED": "bg-green text-black",
+  "ACCEPTED OTHER": "bg-black/10 text-black/50",
+  "EXPIRED": "bg-red text-white",
+  "PENDING": "bg-orange text-white",
 };
+
+const StatusBadge = ({ status }) => (
+  <Badge className={`rounded-full border-black ${STATUS_STYLES[status] || "bg-black/10 text-black/60"}`}>
+    {status}
+  </Badge>
+);
 
 export default function UserOfferCard({ offer }) {
   return (
-    <Card className="mb-12 bg-white gap-0 py-0 pb-4">
-      <CardHeader className="flex flex-col md:flex-row justify-between items-start md:items-center border-b-2 border-border bg-main px-2 py-3 rounded-t-base gap-y-2">
-        <CardTitle>{offer.subject}</CardTitle>
-        <div className="flex items-center gap-x-2">
-          <Badge variant="neutral">
+    <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <h3 className="text-xl">{offer.subject}</h3>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="neutral" className="rounded-full text-xs">
             {formatShort(offer.start_at)}
           </Badge>
-          <span className="block font-bold">:</span>
-          <Badge variant="neutral">
+          <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
+          <Badge variant="neutral" className="rounded-full text-xs">
             {formatShort(offer.end_at)}
           </Badge>
         </div>
-      </CardHeader>
+      </div>
 
-      <div className="px-2 mt-4 flex items-center gap-x-2">
-        <Avatar className="w-12 h-12 shrink-0">
+      <div className="mt-4 flex items-center gap-3">
+        <Avatar className="h-11 w-11 shrink-0 border-2 border-black">
           <AvatarImage src={offer.owner.image_url} alt={offer.owner.name} />
-          <AvatarFallback>{offer.owner.name?.[0]}</AvatarFallback>
+          <AvatarFallback className="bg-orange text-white font-bold">{offer.owner.name?.[0]}</AvatarFallback>
         </Avatar>
         <div>
-          <p>{offer.owner.name}</p>
-          <span className="text-sm">
+          <p className="font-bold text-sm">{offer.owner.name}</p>
+          <span className="text-xs text-black/50">
             {offer.owner.profession}
-            <span className="text-xl font-bold">.</span>
+            {offer.owner.profession && offer.owner.level && " · "}
             {offer.owner.level}
           </span>
         </div>
       </div>
 
-      <CardContent className="px-2 py-4">
-        <ExpandableText className="whitespace-pre-wrap">{offer.message}</ExpandableText>
-      </CardContent>
+      <ExpandableText className="mt-4 whitespace-pre-wrap leading-relaxed text-black/60">{offer.message}</ExpandableText>
 
-      <CardFooter className="flex justify-end px-2">
+      <div className="mt-4 flex justify-end">
         <StatusBadge status={offer.status} />
-      </CardFooter>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/app/javascript/pages/Users/Offers/Index.jsx
+++ b/app/javascript/pages/Users/Offers/Index.jsx
@@ -1,31 +1,32 @@
-import { Head } from "@inertiajs/react";
+import { Head, Link } from "@inertiajs/react";
+import { Send } from "lucide-react";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
+import { Button } from "@/components/ui/button";
 import Card from './Card';
 
 export default function Index({ offers }) {
   return (
-    <div className="flex flex-col items-center">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Applications" />
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center mt-12 pb-8 border-b-4 border-black border-dashed">
-          <h3 className="text-5xl font-bold">Applications</h3>
-        </div>
+      <PageHeader
+        eyebrow="Pair Requests"
+        title="Applications"
+        description="Every offer you've sent, and where it stands."
+      />
 
-        <div className="mt-12">
-          {offers.length > 0 ? (
-            offers.map((offer) => (
-              <Card key={offer.id} offer={offer} />
-            ))
-          ) : (
-            <div className="border-4 border-dashed border-black rounded-md p-12 text-center bg-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-              <p className="text-2xl font-bold italic text-gray-400">
-                You haven't applied to any pair requests yet.
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+      {offers.length > 0 ? (
+        offers.map((offer) => (
+          <Card key={offer.id} offer={offer} />
+        ))
+      ) : (
+        <EmptyState icon={Send} title="You haven't applied to any pair requests yet" description="Browse open requests and find someone to build or learn with.">
+          <Button asChild className="mt-2">
+            <Link href="/pair_requests">Browse requests</Link>
+          </Button>
+        </EmptyState>
+      )}
     </div>
   );
 }
-

--- a/app/javascript/pages/Users/PairRequests/Card.jsx
+++ b/app/javascript/pages/Users/PairRequests/Card.jsx
@@ -1,4 +1,5 @@
 import { useForm, Link } from '@inertiajs/react';
+import { Inbox, CheckCircle2 } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import ExpandableText from "@/components/ExpandableText";
 import { Button } from "@/components/ui/button";
@@ -6,7 +7,8 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+const TAG_COLORS = ["bg-purple text-white", "bg-orange text-white", "bg-green text-black"];
 
 export default function UserPairRequestCard({ request }) {
   const { data, setData, patch, processing } = useForm({
@@ -24,68 +26,67 @@ export default function UserPairRequestCard({ request }) {
   };
 
   return (
-    <Card className="mb-12 bg-white gap-0 py-0 pb-4">
-      <CardHeader className="flex flex-col md:flex-row justify-between items-center border-b-2 border-border bg-main py-4 px-4 rounded-t-base">
-        <CardTitle className="text-xl">{request.subject}</CardTitle>
-        <Button asChild variant="neutral" className="mt-4 md:mt-0">
-          <Link href={`/pair_requests/${request.id}/offers`}>See applications</Link>
+    <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <h3 className="text-xl">{request.subject}</h3>
+        <Button asChild variant="neutral" size="sm">
+          <Link href={`/pair_requests/${request.id}/offers`}>
+            <Inbox className="h-4 w-4" />
+            See applications
+          </Link>
         </Button>
-      </CardHeader>
+      </div>
 
-      <CardContent className="px-4 py-4">
-        <ExpandableText>{request.description}</ExpandableText>
+      <ExpandableText className="mt-3 leading-relaxed text-black/60">{request.description}</ExpandableText>
 
-        <div className="flex w-full overflow-x-auto justify-start space-x-2 mt-4 pb-2">
-          {request.tags?.map((tag) => (
-            <Badge
-              key={tag.id}
-              className="bg-orange shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] 2xl:text-sm"
-            >
-              {tag.name}
-            </Badge>
-          ))}
-        </div>
-      </CardContent>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {request.tags?.map((tag, i) => (
+          <Badge key={tag.id} className={`rounded-full border-black ${TAG_COLORS[i % TAG_COLORS.length]}`}>
+            {tag.name}
+          </Badge>
+        ))}
+      </div>
 
       {request.accepted_offer && (
-        <div className="px-4 pt-4 mt-2">
-          <div className="flex flex-col md:flex-row items-center justify-between gap-y-4">
-            <div className="flex items-center gap-x-2 w-full md:w-1/2">
-              <Avatar className="w-12 h-12 shrink-0">
+        <div className="mt-5 rounded-xl border-2 border-black bg-green/10 p-4">
+          <Badge className="mb-3 rounded-full border-black bg-green text-black uppercase tracking-widest">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Matched
+          </Badge>
+
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-11 w-11 shrink-0 border-2 border-black">
                 <AvatarImage src={request.accepted_offer.offerer_image} alt={request.accepted_offer.offerer_name} />
-                <AvatarFallback>{request.accepted_offer.offerer_name?.[0]}</AvatarFallback>
+                <AvatarFallback className="bg-orange text-white font-bold">{request.accepted_offer.offerer_name?.[0]}</AvatarFallback>
               </Avatar>
               <div>
-                <p className="font-bold">{request.accepted_offer.offerer_name}</p>
-                <span className="text-sm">
+                <p className="font-bold text-sm">{request.accepted_offer.offerer_name}</p>
+                <span className="text-xs text-black/50">
                   {request.accepted_offer.offerer_profession}
-                  <span className="text-gray-400 font-black"> &bull; </span>
+                  {request.accepted_offer.offerer_profession && " · "}
                   {request.accepted_offer.offerer_level}
                 </span>
               </div>
             </div>
 
-            <div className="flex flex-col gap-y-1 w-full md:w-1/2 md:items-end">
+            <div className="flex flex-col gap-1 md:items-end">
               {request.sessions.map(s => (
-                <div key={s.id} className="flex items-center gap-x-1">
-                  <Badge variant="neutral" className="text-sm px-3">
+                <div key={s.id} className="flex items-center gap-1.5">
+                  <Badge variant="neutral" className="rounded-full text-xs">
                     {formatShort(s.start_at)}
                   </Badge>
-                  <span className="font-bold">:</span>
-                  <Badge variant="neutral" className="text-sm px-3">
+                  <span className="text-black/30">→</span>
+                  <Badge variant="neutral" className="rounded-full text-xs">
                     {formatShort(s.end_at)}
                   </Badge>
                 </div>
               ))}
             </div>
           </div>
-        </div>
-      )}
 
-      {request.accepted_offer && (
-        <div className="px-4 mt-6">
-          <form onSubmit={submitCallLink} className="flex flex-col md:flex-row w-full gap-y-4 md:gap-x-2 items-center md:items-end">
-            <div className="flex flex-col w-full">
+          <form onSubmit={submitCallLink} className="mt-4 flex flex-col items-stretch gap-2 md:flex-row md:items-end">
+            <div className="flex flex-1 flex-col">
               <Label htmlFor="pair_request_sessions_attributes_0_call_link" className="mb-1">Call link</Label>
               <Input
                 id="pair_request_sessions_attributes_0_call_link"
@@ -97,14 +98,15 @@ export default function UserPairRequestCard({ request }) {
                   setData('pair_request', { ...data.pair_request, sessions_attributes: newAttrs });
                 }}
                 placeholder="https://meet.google.com/..."
+                className="bg-white"
               />
             </div>
-            <Button disabled={processing} className="w-full md:w-1/4">
+            <Button disabled={processing} className="md:w-32">
               {processing ? '...' : 'Add'}
             </Button>
           </form>
         </div>
       )}
-    </Card>
+    </div>
   );
 }

--- a/app/javascript/pages/Users/PairRequests/Index.jsx
+++ b/app/javascript/pages/Users/PairRequests/Index.jsx
@@ -17,9 +17,11 @@ export default function Index({ pairRequests }) {
       />
 
       {pairRequests && pairRequests.length > 0 ? (
-        pairRequests.map((request) => (
-          <Card key={request.id} request={request} />
-        ))
+        <div id="pair_requests">
+          {pairRequests.map((request) => (
+            <Card key={request.id} request={request} />
+          ))}
+        </div>
       ) : (
         <EmptyState icon={ClipboardList} title="You haven't opened any requests yet" description="Post what you're working on and let the community come to you.">
           <Button asChild className="mt-2">

--- a/app/javascript/pages/Users/PairRequests/Index.jsx
+++ b/app/javascript/pages/Users/PairRequests/Index.jsx
@@ -1,29 +1,32 @@
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
+import { ClipboardList } from "lucide-react";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
+import { Button } from "@/components/ui/button";
 import Card from './Card';
 
 export default function Index({ pairRequests }) {
   return (
-    <div className="flex justify-center">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Your Requests" />
 
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full flex-wrap items-center justify-center mt-12 pb-8 border-b-4 border-black border-dashed">
-          <h3 className="w-full text-5xl font-bold">Your requests</h3>
-        </div>
+      <PageHeader
+        eyebrow="Pair Requests"
+        title="Your requests"
+        description="Requests you've opened, and who's applied to work with you."
+      />
 
-        <div id="pair_requests" className="mt-12">
-          {pairRequests && pairRequests.length > 0 ? (
-            pairRequests.map((request) => (
-              <Card key={request.id} request={request} />
-            ))
-          ) : (
-            <div className="text-center py-20 bg-white border-4 border-black border-dashed rounded-lg">
-              <p className="text-xl font-bold">You haven't opened any requests yet.</p>
-            </div>
-          )}
-        </div>
-      </div>
+      {pairRequests && pairRequests.length > 0 ? (
+        pairRequests.map((request) => (
+          <Card key={request.id} request={request} />
+        ))
+      ) : (
+        <EmptyState icon={ClipboardList} title="You haven't opened any requests yet" description="Post what you're working on and let the community come to you.">
+          <Button asChild className="mt-2">
+            <Link href="/users/pair_requests/new">Create a request</Link>
+          </Button>
+        </EmptyState>
+      )}
     </div>
   );
 }
-

--- a/app/javascript/pages/Users/PairRequests/New.jsx
+++ b/app/javascript/pages/Users/PairRequests/New.jsx
@@ -1,4 +1,6 @@
 import { useForm, Head } from '@inertiajs/react';
+import { X } from "lucide-react";
+import PageHeader from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
@@ -63,86 +65,89 @@ export default function New({ tags }) {
 
   const addTag = () => {
     const updatedTaggings = [...data.taggings_attributes];
-    
-    updatedTaggings.push({ 
-      tag_attributes: { name: '' } 
+
+    updatedTaggings.push({
+      tag_attributes: { name: '' }
     });
     setData('taggings_attributes', updatedTaggings);
   };
 
   const removeTag = (index) => {
     const updatedTaggings = [...data.taggings_attributes];
-    
+
     updatedTaggings.splice(index, 1);
     setData('taggings_attributes', updatedTaggings);
   };
 
   const updateTag = (index, name) => {
     const updatedTaggings = [...data.taggings_attributes];
-    
+
     updatedTaggings[index] = {
       tag_attributes: { name: name }
     };
-    
+
     setData('taggings_attributes', updatedTaggings);
   };
 
   return (
-    <div className="flex flex-col items-center w-full px-4">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
       <Head title="Create a Request" />
-      <div className="w-full md:w-3/4 xl:w-4/6 2xl:w-1/2">
-        <div className="flex w-full items-center mt-8 pb-8 border-b-4 border-black border-dashed text-center">
-          <h3 className="text-5xl font-bold">Create a request</h3>
+
+      <PageHeader
+        eyebrow="Pair Requests"
+        title="Create a request"
+        description="Share what you're working on, when you're free, and what stack you're looking for."
+      />
+
+      <form onSubmit={handleSubmit} className="flex flex-col items-stretch">
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="w-full md:w-3/4">
+            <Label htmlFor="subject" className="block mb-1">Subject</Label>
+            <Input
+              id="subject"
+              type="text"
+              value={data.subject}
+              onChange={e => setData('subject', e.target.value)}
+            />
+            {errors.subject && <div className="text-red font-bold mt-1 text-sm">{errors.subject}</div>}
+          </div>
+
+          <div className="w-full md:w-1/4">
+            <Label htmlFor="duration" className="block mb-1">Duration (min)</Label>
+            <Input
+              id="duration"
+              type="number"
+              value={data.duration}
+              onChange={e => setData('duration', e.target.value)}
+            />
+            {errors.duration && <div className="text-red font-bold mt-1 text-sm">{errors.duration}</div>}
+          </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col items-center pb-12 mt-12">
-          <div className="flex w-full gap-x-4">
-            <div className="w-3/4 pair_request_subject">
-              <Label htmlFor="subject" className="block mb-1">Subject</Label>
-              <Input
-                id="subject"
-                type="text"
-                value={data.subject}
-                onChange={e => setData('subject', e.target.value)}
-              />
-              {errors.subject && <div className="text-red-600 font-bold mt-1">{errors.subject}</div>}
-            </div>
+        <div className="w-full mt-4">
+          <Label htmlFor="description" className="block mb-1">Description</Label>
+          <Textarea
+            id="description"
+            value={data.description}
+            onChange={e => setData('description', e.target.value)}
+            rows="4"
+          />
+          {errors.description && <div className="text-red font-bold mt-1 text-sm">{errors.description}</div>}
+        </div>
 
-            <div className="w-1/4 pair_request_duration">
-              <Label htmlFor="duration" className="block mb-1">Duration (min)</Label>
-              <Input
-                id="duration"
-                type="number"
-                value={data.duration}
-                onChange={e => setData('duration', e.target.value)}
-              />
-              {errors.duration && <div className="text-red-600 font-bold mt-1">{errors.duration}</div>}
-            </div>
-          </div>
+        <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div>
+            <h4 className="mb-3 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Periods</h4>
 
-          <div className="w-full mt-4 pair_request_description">
-            <Label htmlFor="description" className="block mb-1">Description</Label>
-            <Textarea
-              id="description"
-              value={data.description}
-              onChange={e => setData('description', e.target.value)}
-              rows="4"
-            />
-            {errors.description && <div className="text-red-600 font-bold mt-1">{errors.description}</div>}
-          </div>
-
-          <div className="flex flex-col gap-y-8 mt-8 items-start w-full md:flex-row md:gap-x-4 md:gap-y-0">
-            <div className="w-full md:w-1/2">
-              <h4 className="font-bold mb-4 underline">Periods</h4>
-              
+            <div className="flex flex-col gap-3">
               {data.periods_attributes.map((period, index) => {
                 const { date, time } = splitStartAt(period.start_at);
 
                 return (
-                  <div key={index} className="mb-4 p-2 border-2 border-black rounded-md bg-white">
-                    <Label className="block mb-1 text-gray-700">Start at</Label>
-                    <div className="flex flex-col gap-2 md:flex-row md:gap-x-2">
-                      <div className="md:w-7/12">
+                  <div key={index} className="rounded-xl border-2 border-black bg-white p-3">
+                    <Label className="mb-1 block text-black/50">Start at</Label>
+                    <div className="flex flex-col gap-2 md:flex-row">
+                      <div className="md:flex-1">
                         <DatePicker
                           value={date}
                           onChange={(v) => updatePeriodPart(index, 'date', v)}
@@ -150,7 +155,7 @@ export default function New({ tags }) {
                           disabled={(d) => d < new Date(new Date().setHours(0, 0, 0, 0))}
                         />
                       </div>
-                      <div className="flex gap-x-2 md:w-5/12">
+                      <div className="flex gap-2">
                         <div className="flex-1">
                           <Select value={time} onValueChange={(v) => updatePeriodPart(index, 'time', v)}>
                             <SelectTrigger className="w-full">
@@ -165,40 +170,42 @@ export default function New({ tags }) {
                         </div>
                         <Button
                           type="button"
-                          size="sm"
+                          size="icon"
                           variant="neutral"
                           onClick={() => removePeriod(index)}
-                          className="text-red-500"
+                          aria-label="Remove period"
                         >
-                          X
+                          <X className="h-4 w-4" />
                         </Button>
                       </div>
                     </div>
                     {errors["periods.start_at"] && !isValidStartAt(period.start_at) && (
-                      <div className="text-red-600 font-bold mt-1">
+                      <div className="text-red font-bold mt-1 text-sm">
                         {errors["periods.start_at"]}
                       </div>
                     )}
                   </div>
                 );
               })}
-
-              <Button type="button" size="sm" variant="neutral" onClick={addPeriod} className="mt-2">
-                + Add period
-              </Button>
             </div>
 
-            <div className="w-full md:w-1/2">
-              <h4 className="font-bold mb-4 underline">Tags</h4>
-              
+            <Button type="button" size="sm" variant="neutral" onClick={addPeriod} className="mt-3">
+              + Add period
+            </Button>
+          </div>
+
+          <div>
+            <h4 className="mb-3 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Tags</h4>
+
+            <div className="flex flex-col gap-3">
               {data.taggings_attributes.map((tagging, index) => (
-                <div key={index} className="mb-4 p-2 border-2 border-black rounded-md bg-white">
-                  <Label className="block mb-1 text-gray-700">
+                <div key={index} className="rounded-xl border-2 border-black bg-white p-3">
+                  <Label className="mb-1 block text-black/50">
                     Tag <span className="text-xs font-normal">(select or type new)</span>
                   </Label>
 
-                  <div className="flex gap-x-2">
-                    <div className="w-10/12 relative">
+                  <div className="flex gap-2">
+                    <div className="relative flex-1">
                       <Input
                         list={`tags-list-${index}`}
                         value={tagging.tag_attributes.name}
@@ -214,36 +221,35 @@ export default function New({ tags }) {
 
                     <Button
                       type="button"
-                      size="sm"
+                      size="icon"
                       variant="neutral"
                       onClick={() => removeTag(index)}
-                      className="w-2/12 text-red-500"
+                      aria-label="Remove tag"
                     >
-                      X
+                      <X className="h-4 w-4" />
                     </Button>
                   </div>
                   {errors[`taggings_attributes.${index}.tag_attributes.name`] && (
-                    <div className="text-red-600 text-xs font-bold mt-1">
+                    <div className="text-red text-xs font-bold mt-1">
                       {errors[`taggings_attributes.${index}.tag_attributes.name`]}
                     </div>
                   )}
                 </div>
               ))}
+            </div>
 
-              <div className="flex justify-start md:justify-end mt-2">
-                <Button type="button" size="sm" variant="neutral" onClick={addTag}>
-                  + Add tag
-                </Button>
-              </div>
+            <div className="mt-3 flex justify-start">
+              <Button type="button" size="sm" variant="neutral" onClick={addTag}>
+                + Add tag
+              </Button>
             </div>
           </div>
-          
-          <Button type="submit" size="lg" disabled={processing} className="mt-12">
-            {processing ? 'Creating...' : 'Create Pair request'}
-          </Button>
-        </form>
-      </div>
+        </div>
+
+        <Button type="submit" size="lg" disabled={processing} className="mt-12 self-center">
+          {processing ? 'Creating...' : 'Create Pair request'}
+        </Button>
+      </form>
     </div>
   );
 }
-

--- a/app/javascript/pages/Users/PairRequests/New.jsx
+++ b/app/javascript/pages/Users/PairRequests/New.jsx
@@ -101,7 +101,7 @@ export default function New({ tags }) {
 
       <form onSubmit={handleSubmit} className="flex flex-col items-stretch">
         <div className="flex flex-col gap-4 md:flex-row">
-          <div className="w-full md:w-3/4">
+          <div className="pair_request_subject w-full md:w-3/4">
             <Label htmlFor="subject" className="block mb-1">Subject</Label>
             <Input
               id="subject"
@@ -112,7 +112,7 @@ export default function New({ tags }) {
             {errors.subject && <div className="text-red font-bold mt-1 text-sm">{errors.subject}</div>}
           </div>
 
-          <div className="w-full md:w-1/4">
+          <div className="pair_request_duration w-full md:w-1/4">
             <Label htmlFor="duration" className="block mb-1">Duration (min)</Label>
             <Input
               id="duration"
@@ -124,7 +124,7 @@ export default function New({ tags }) {
           </div>
         </div>
 
-        <div className="w-full mt-4">
+        <div className="pair_request_description w-full mt-4">
           <Label htmlFor="description" className="block mb-1">Description</Label>
           <Textarea
             id="description"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
         orange: "#FF8B37",
         purple: "#7B5FF1",
         green: "#55D087",
+        red: "#F1495F",
         // neobrutalism token colors (consumed by installed components)
         main: 'var(--main)',
         'main-foreground': 'var(--main-foreground)',
@@ -37,7 +38,7 @@ module.exports = {
         shadow: 'var(--shadow)',
       },
       borderRadius: {
-        base: '5px',
+        base: '0.75rem',
       },
       translate: {
         boxShadowX: '4px',


### PR DESCRIPTION
## Summary
- Rebuilt the sidebar nav (desktop + mobile drawer) with icon-driven items, replacing the old dashed-border row stack
- Retheme: primary color switched from lime to the brand purple used on the landing page, corner radius softened, headings switched to the Outfit display font site-wide
- Redesigned Search, Feed, Pair Requests (opened/new), Applications (sent/received), Profile, and Sessions pages with consistent card, header, and empty-state components

## Test plan
- [ ] Click through each nav item on desktop and mobile (drawer open/close, Escape, backdrop click)
- [ ] Verify Search/List, Feed, Pair Requests, Applications, Profile, and Sessions pages render as expected
- [ ] Confirm buttons/badges use the new purple brand color everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnW3ncV4KHCeq1TAtXjue