### PR TITLE
Immediate-mode request creation + live/scheduled browse split

### DIFF
--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -1,12 +1,6 @@
 class PairRequestsController < ApplicationController
   include Authenticated
-
-  PAIR_REQUEST_JSON_INCLUDE = {
-    user: { only: [:id, :name, :profession], methods: [:image_url, :level_titleized] },
-    tags: { only: [:id, :name] },
-    periods: { only: [:id, :start_at, :end_at] },
-    offers: { only: [:offerer_id] }
-  }.freeze
+  include Alba::Inertia::Controller
 
   def index
     live_pair_requests = PairRequest
@@ -30,9 +24,10 @@ class PairRequestsController < ApplicationController
 
     render inertia: 'PairRequests/Index', props: {
       filters: params[:q]&.compact_blank || {},
-      livePairRequests: live_pair_requests.as_json(include: PAIR_REQUEST_JSON_INCLUDE),
+      livePairRequests: PairRequestBrowseResource.new(live_pair_requests),
+      scheduledPairRequestsCount: @pagy.count,
       scheduledPairRequests: InertiaRails.scroll(@pagy) {
-        @scheduled_pair_requests.as_json(include: PAIR_REQUEST_JSON_INCLUDE)
+        PairRequestBrowseResource.new(@scheduled_pair_requests)
       },
       filterOptions: InertiaRails.once {
         {

--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -1,14 +1,28 @@
 class PairRequestsController < ApplicationController
   include Authenticated
+
+  PAIR_REQUEST_JSON_INCLUDE = {
+    user: { only: [:id, :name, :profession], methods: [:image_url, :level_titleized] },
+    tags: { only: [:id, :name] },
+    periods: { only: [:id, :start_at, :end_at] },
+    offers: { only: [:offerer_id] }
+  }.freeze
+
   def index
+    live_pair_requests = PairRequest
+      .includes(:periods, :tags, :user, :offers)
+      .live_now
+      .where.not(user_id: current_user.id)
+      .distinct
+
     base = PairRequest
       .includes(:periods, :tags, :user, :offers)
       .left_joins(:periods, :tags, :user)
-      .active
+      .scheduled_active
       .where.not(user_id: current_user.id)
 
     @q = base.ransack(params[:q]&.compact_blank)
-    @pagy, @pair_requests = pagy(
+    @pagy, @scheduled_pair_requests = pagy(
       @q.result(distinct: true).order('periods.start_at ASC'),
       items: 15,
       overflow: :empty_page,
@@ -16,15 +30,9 @@ class PairRequestsController < ApplicationController
 
     render inertia: 'PairRequests/Index', props: {
       filters: params[:q]&.compact_blank || {},
-      pairRequests: InertiaRails.scroll(@pagy) {
-        @pair_requests.as_json(
-          include: {
-            user: { only: [:id, :name, :profession], methods: [:image_url, :level_titleized] },
-            tags: { only: [:id, :name] },
-            periods: { only: [:id, :start_at, :end_at] },
-            offers: { only: [:offerer_id] }
-          }
-        )
+      livePairRequests: live_pair_requests.as_json(include: PAIR_REQUEST_JSON_INCLUDE),
+      scheduledPairRequests: InertiaRails.scroll(@pagy) {
+        @scheduled_pair_requests.as_json(include: PAIR_REQUEST_JSON_INCLUDE)
       },
       filterOptions: InertiaRails.once {
         {

--- a/app/controllers/users/pair_requests_controller.rb
+++ b/app/controllers/users/pair_requests_controller.rb
@@ -14,14 +14,17 @@ class Users::PairRequestsController < ApplicationController
 
   def new
     @pair_request = current_user.pair_requests.build
-    
+
     render inertia: 'Users/PairRequests/New', props: {
-      tags: TagResource.new(Tag.select(:id, :name))
+      tags: TagResource.new(Tag.select(:id, :name)),
+      waitMinutesOptions: PairRequest::WAIT_MINUTES_OPTIONS,
+      platformOptions: PairRequest::PLATFORMS
     }
   end
 
   def create
     @pair_request = current_user.pair_requests.build(pair_request_params)
+    @pair_request.periods = [Period.new(start_at: Time.current)] if @pair_request.mode == "immediate"
 
     if @pair_request.save
       redirect_to users_pair_requests_path, notice: "Request posted! Good luck"
@@ -54,6 +57,13 @@ class Users::PairRequestsController < ApplicationController
         :subject,
         :description,
         :duration,
+        :mode,
+        :wait_minutes,
+        :requires_approval,
+        :goal,
+        :platform,
+        :pairing_tool,
+        :plan,
         periods_attributes: [:start_at, :_destroy],
         taggings_attributes: [:_destroy, tag_attributes: [:name]]
       )

--- a/app/javascript/components/FilterForm.jsx
+++ b/app/javascript/components/FilterForm.jsx
@@ -32,8 +32,6 @@ export default function FilterForm({ tags, userLevels, languages, filters = {}, 
 
   return (
     <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
-      <p className="font-headline font-bold text-sm">Refine your search</p>
-
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div>
         <Label htmlFor="tags_name_eq" className="block mb-1">

--- a/app/javascript/components/ui/command.jsx
+++ b/app/javascript/components/ui/command.jsx
@@ -1,0 +1,137 @@
+import { Command as CommandPrimitive } from "cmdk"
+import { Search } from "lucide-react"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Command({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-base border-2 border-border bg-secondary-background font-base text-foreground",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 gap-2 items-center border-b-2 border-border px-3"
+    >
+      <Search className="size-4 shrink-0" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-base bg-transparent py-3 text-sm outline-hidden placeholder:text-foreground placeholder:opacity-50 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props} />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn("py-6 text-center text-sm", className)}
+      {...props} />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground overflow-hidden p-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-base [&_[cmdk-group-heading]]:font-heading",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-0.5 bg-border", className)}
+      {...props} />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-base px-2 py-1.5 gap-2 text-sm text-foreground outline-border outline-0 aria-selected:outline-2 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-foreground",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/app/javascript/components/ui/tabs.jsx
+++ b/app/javascript/components/ui/tabs.jsx
@@ -1,0 +1,64 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("w-full", className)}
+      {...props} />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "inline-flex h-12 items-center justify-center rounded-base border-2 border-border bg-background p-1 text-foreground",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-base border-2 border-transparent px-2 py-1 gap-1.5 text-sm font-heading ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-main data-[state=active]:text-main-foreground data-[state=active]:border-border",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn(
+        "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props} />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/app/javascript/pages/PairRequests/Card.jsx
+++ b/app/javascript/pages/PairRequests/Card.jsx
@@ -8,7 +8,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
 const TAG_COLORS = ["bg-purple text-white", "bg-orange text-white", "bg-green text-black"];
 
-export default function PairRequestCard({ pairRequest, currentUserId }) {
+export default function PairRequestCard({ pairRequest, currentUserId, live = false }) {
   const alreadyOffered = pairRequest.offers
     ?.map(o => o.offerer_id)
     .includes(currentUserId);
@@ -18,22 +18,34 @@ export default function PairRequestCard({ pairRequest, currentUserId }) {
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <h3 className="text-xl">{pairRequest.subject}</h3>
 
-        <div className="flex flex-wrap gap-2 md:flex-col md:items-end">
-          {pairRequest.periods.map((period) => (
-            <div key={period.id} className="flex items-center gap-1.5">
-              <Badge variant="neutral" className="rounded-full text-xs">
-                {formatShort(period.start_at)}
-              </Badge>
-              <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
-              <Badge variant="neutral" className="rounded-full text-xs">
-                {formatShort(period.end_at)}
-              </Badge>
-            </div>
-          ))}
-        </div>
+        {live ? (
+          <Badge className="rounded-full border-black bg-green text-black text-xs">Live now</Badge>
+        ) : (
+          <div className="flex flex-wrap gap-2 md:flex-col md:items-end">
+            {pairRequest.periods.map((period) => (
+              <div key={period.id} className="flex items-center gap-1.5">
+                <Badge variant="neutral" className="rounded-full text-xs">
+                  {formatShort(period.start_at)}
+                </Badge>
+                <ArrowRight className="h-3 w-3 shrink-0 text-black/30" />
+                <Badge variant="neutral" className="rounded-full text-xs">
+                  {formatShort(period.end_at)}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <ExpandableText className="mt-3 leading-relaxed text-black/60">{pairRequest.description}</ExpandableText>
+
+      {live && pairRequest.goal && (
+        <p className="mt-3 text-sm text-black/60"><span className="font-bold text-black">Goal:</span> {pairRequest.goal}</p>
+      )}
+
+      {live && pairRequest.platform && (
+        <p className="mt-1 text-sm text-black/60"><span className="font-bold text-black">Platform:</span> {pairRequest.platform}</p>
+      )}
 
       <div className="mt-4 flex flex-wrap gap-2">
         {pairRequest.tags.map((tag, i) => (
@@ -59,12 +71,14 @@ export default function PairRequestCard({ pairRequest, currentUserId }) {
           </div>
         </div>
 
-        {alreadyOffered ? (
-          <span className="text-sm font-bold italic text-black/40">You have already sent an offer</span>
-        ) : (
-          <Button asChild>
-            <Link href={`/pair_requests/${pairRequest.id}/offers/new`}>Apply</Link>
-          </Button>
+        {!live && (
+          alreadyOffered ? (
+            <span className="text-sm font-bold italic text-black/40">You have already sent an offer</span>
+          ) : (
+            <Button asChild>
+              <Link href={`/pair_requests/${pairRequest.id}/offers/new`}>Apply</Link>
+            </Button>
+          )
         )}
       </div>
     </div>

--- a/app/javascript/pages/PairRequests/Index.jsx
+++ b/app/javascript/pages/PairRequests/Index.jsx
@@ -7,7 +7,7 @@ import Card from "./Card";
 import { Head, router, usePage, InfiniteScroll } from "@inertiajs/react";
 import { SlidersHorizontal, SearchX } from "lucide-react";
 
-export default function Index({ pairRequests, filterOptions, filters }) {
+export default function Index({ livePairRequests, scheduledPairRequests, filterOptions, filters }) {
   const { auth } = usePage().props;
   const currentUser = auth.user;
 
@@ -46,30 +46,45 @@ export default function Index({ pairRequests, filterOptions, filters }) {
         }
       />
 
-      <div className="relative flex flex-col gap-6">
-        <InfiniteScroll
-          data="pairRequests"
-          loading={() => (
-            <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
-          )}
-          next={({ hasMore }) =>
-            !hasMore && pairRequests.length > 0 ? (
-              <div className="flex justify-center py-8 text-black/40">No more requests</div>
-            ) : null
-          }
-        >
-          {pairRequests.map((req) => (
-            <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
-          ))}
-        </InfiniteScroll>
+      {livePairRequests.length > 0 && (
+        <div className="mb-10">
+          <h2 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Live now</h2>
+          <div className="flex flex-col gap-6">
+            {livePairRequests.map((req) => (
+              <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} live />
+            ))}
+          </div>
+        </div>
+      )}
 
-        {pairRequests.length === 0 && (
-          <EmptyState
-            icon={SearchX}
-            title="No requests match your search"
-            description="Try widening your filters or check back soon — new requests come in all the time."
-          />
-        )}
+      <div>
+        <h2 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Scheduled</h2>
+
+        <div className="relative flex flex-col gap-6">
+          <InfiniteScroll
+            data="scheduledPairRequests"
+            loading={() => (
+              <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
+            )}
+            next={({ hasMore }) =>
+              !hasMore && scheduledPairRequests.length > 0 ? (
+                <div className="flex justify-center py-8 text-black/40">No more requests</div>
+              ) : null
+            }
+          >
+            {scheduledPairRequests.map((req) => (
+              <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
+            ))}
+          </InfiniteScroll>
+
+          {scheduledPairRequests.length === 0 && (
+            <EmptyState
+              icon={SearchX}
+              title="No requests match your search"
+              description="Try widening your filters or check back soon — new requests come in all the time."
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/javascript/pages/PairRequests/Index.jsx
+++ b/app/javascript/pages/PairRequests/Index.jsx
@@ -1,15 +1,18 @@
+import { useState } from "react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import PageHeader from "@/components/PageHeader";
 import EmptyState from "@/components/EmptyState";
 import FilterForm from "@/components/FilterForm";
 import Card from "./Card";
 import { Head, router, usePage, InfiniteScroll } from "@inertiajs/react";
-import { SlidersHorizontal, SearchX } from "lucide-react";
+import { SlidersHorizontal, SearchX, Radio, CalendarClock } from "lucide-react";
 
-export default function Index({ livePairRequests, scheduledPairRequests, filterOptions, filters }) {
+export default function Index({ livePairRequests, scheduledPairRequests, scheduledPairRequestsCount, filterOptions, filters }) {
   const { auth } = usePage().props;
   const currentUser = auth.user;
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const { tags, userLevels, languages } = filterOptions;
 
@@ -21,71 +24,93 @@ export default function Index({ livePairRequests, scheduledPairRequests, filterO
         eyebrow="Search"
         title="Pair Programming Requests"
         description="Browse open requests from the community and find a partner to build or learn with."
-        action={
-          <Collapsible>
+      />
+
+      <Tabs defaultValue={livePairRequests.length > 0 ? "live" : "scheduled"} className="mt-8">
+        <Collapsible open={filtersOpen} onOpenChange={setFiltersOpen}>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <TabsList>
+              <TabsTrigger value="live" className="gap-2 px-4">
+                <Radio className="h-4 w-4" />
+                Live now
+                <span className="text-xs opacity-60">{livePairRequests.length}</span>
+              </TabsTrigger>
+              <TabsTrigger value="scheduled" className="gap-2 px-4">
+                <CalendarClock className="h-4 w-4" />
+                Scheduled
+                <span className="text-xs opacity-60">{scheduledPairRequestsCount}</span>
+              </TabsTrigger>
+            </TabsList>
+
             <CollapsibleTrigger asChild>
               <Button variant="neutral" size="sm">
                 <SlidersHorizontal className="h-4 w-4" />
                 Filters
               </Button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="w-full">
-              <div className="fixed inset-x-4 top-24 z-40 rounded-2xl border-2 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-3 md:w-[560px]">
-                <FilterForm
-                  tags={tags}
-                  userLevels={userLevels}
-                  languages={languages}
-                  filters={filters}
-                  onSubmit={(q) => {
-                    router.get("/pair_requests", { q });
-                  }}
-                />
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        }
-      />
-
-      {livePairRequests.length > 0 && (
-        <div className="mb-10">
-          <h2 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Live now</h2>
-          <div className="flex flex-col gap-6">
-            {livePairRequests.map((req) => (
-              <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} live />
-            ))}
           </div>
-        </div>
-      )}
 
-      <div>
-        <h2 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Scheduled</h2>
+          <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
+            <div className="mt-4 rounded-2xl border-2 border-black bg-white p-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+              <p className="mb-4 font-headline text-sm font-bold">Refine your search</p>
+              <FilterForm
+                tags={tags}
+                userLevels={userLevels}
+                languages={languages}
+                filters={filters}
+                onSubmit={(q) => {
+                  setFiltersOpen(false);
+                  router.get("/pair_requests", { q });
+                }}
+              />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
 
-        <div className="relative flex flex-col gap-6">
-          <InfiniteScroll
-            data="scheduledPairRequests"
-            loading={() => (
-              <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
-            )}
-            next={({ hasMore }) =>
-              !hasMore && scheduledPairRequests.length > 0 ? (
-                <div className="flex justify-center py-8 text-black/40">No more requests</div>
-              ) : null
-            }
-          >
-            {scheduledPairRequests.map((req) => (
-              <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
-            ))}
-          </InfiniteScroll>
-
-          {scheduledPairRequests.length === 0 && (
+        <TabsContent value="live" className="mt-6">
+          {livePairRequests.length > 0 ? (
+            <div className="flex flex-col gap-6">
+              {livePairRequests.map((req) => (
+                <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} live />
+              ))}
+            </div>
+          ) : (
             <EmptyState
-              icon={SearchX}
-              title="No requests match your search"
-              description="Try widening your filters or check back soon — new requests come in all the time."
+              icon={Radio}
+              title="No one is live right now"
+              description="Check the Scheduled tab to line up a session ahead of time."
             />
           )}
-        </div>
-      </div>
+        </TabsContent>
+
+        <TabsContent value="scheduled" className="mt-6">
+          <div className="relative flex flex-col gap-6">
+            <InfiniteScroll
+              data="scheduledPairRequests"
+              loading={() => (
+                <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
+              )}
+              next={({ hasMore }) =>
+                !hasMore && scheduledPairRequests.length > 0 ? (
+                  <div className="flex justify-center py-8 text-black/40">No more requests</div>
+                ) : null
+              }
+            >
+              {scheduledPairRequests.map((req) => (
+                <Card key={req.id} pairRequest={req} currentUserId={currentUser.id} />
+              ))}
+            </InfiniteScroll>
+
+            {scheduledPairRequests.length === 0 && (
+              <EmptyState
+                icon={SearchX}
+                title="No requests match your search"
+                description="Try widening your filters or check back soon — new requests come in all the time."
+              />
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/app/javascript/pages/Users/PairRequests/New.jsx
+++ b/app/javascript/pages/Users/PairRequests/New.jsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DatePicker } from "@/components/ui/date-picker";
 import { TIME_SLOTS } from "@/helpers/time-slots";
+import TagCombobox from "./TagCombobox";
 
 const splitStartAt = (startAt) => {
   if (!startAt) return { date: '', time: '' };
@@ -346,18 +347,12 @@ export default function New({ tags, waitMinutesOptions, platformOptions }) {
                   </Label>
 
                   <div className="flex gap-2">
-                    <div className="relative flex-1">
-                      <Input
-                        list={`tags-list-${index}`}
+                    <div className="flex-1">
+                      <TagCombobox
+                        tags={tags}
                         value={tagging.tag_attributes.name}
-                        onChange={(e) => updateTag(index, e.target.value)}
-                        placeholder="Search or create..."
+                        onChange={(name) => updateTag(index, name)}
                       />
-                      <datalist id={`tags-list-${index}`}>
-                        {tags.map((t) => (
-                          <option key={t.value} value={t.label} />
-                        ))}
-                      </datalist>
                     </div>
 
                     <Button

--- a/app/javascript/pages/Users/PairRequests/New.jsx
+++ b/app/javascript/pages/Users/PairRequests/New.jsx
@@ -19,24 +19,43 @@ const combineStartAt = (date, time) => (date || time ? `${date}T${time}` : '');
 
 const isValidStartAt = (s) => /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(s);
 
-export default function New({ tags }) {
+const humanize = (value) => value.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+export default function New({ tags, waitMinutesOptions, platformOptions }) {
   const { data, setData, post, processing, errors, transform } = useForm({
     subject: '',
     duration: 45,
     description: '',
+    mode: 'scheduled',
+    wait_minutes: '',
+    requires_approval: false,
+    goal: '',
+    platform: '',
+    pairing_tool: '',
+    plan: '',
     periods_attributes: [{start_at: ''}],
     taggings_attributes: [{ tag_attributes: { name: '' } }]
   })
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    transform((formData) => ({
-      ...formData,
-      periods_attributes: formData.periods_attributes.map((p) => ({
-        ...p,
-        start_at: isValidStartAt(p.start_at) ? new Date(p.start_at).toISOString() : '',
-      })),
-    }));
+    transform((formData) => (
+      formData.mode === 'scheduled'
+        ? {
+            ...formData,
+            wait_minutes: '',
+            requires_approval: false,
+            goal: '',
+            platform: '',
+            pairing_tool: '',
+            plan: '',
+            periods_attributes: formData.periods_attributes.map((p) => ({
+              ...p,
+              start_at: isValidStartAt(p.start_at) ? new Date(p.start_at).toISOString() : '',
+            })),
+          }
+        : { ...formData, periods_attributes: [] }
+    ));
     post('/users/pair_requests');
   }
 
@@ -135,7 +154,128 @@ export default function New({ tags }) {
           {errors.description && <div className="text-red font-bold mt-1 text-sm">{errors.description}</div>}
         </div>
 
-        <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="w-full mt-4">
+          <Label className="block mb-1">Mode</Label>
+          <div className="flex gap-2" role="radiogroup" aria-label="Mode">
+            <Button
+              type="button"
+              role="radio"
+              aria-checked={data.mode === 'scheduled'}
+              variant={data.mode === 'scheduled' ? 'default' : 'neutral'}
+              onClick={() => setData('mode', 'scheduled')}
+            >
+              Scheduled
+            </Button>
+            <Button
+              type="button"
+              role="radio"
+              aria-checked={data.mode === 'immediate'}
+              variant={data.mode === 'immediate' ? 'default' : 'neutral'}
+              onClick={() => setData('mode', 'immediate')}
+            >
+              Immediate
+            </Button>
+          </div>
+          {errors.mode && <div className="text-red font-bold mt-1 text-sm">{errors.mode}</div>}
+        </div>
+
+        {data.mode === 'immediate' && (
+          <div className="w-full mt-6 flex flex-col gap-4 rounded-xl border-2 border-black bg-white p-4">
+            <div className="flex flex-col gap-4 md:flex-row">
+              <div className="w-full md:w-1/2">
+                <Label className="block mb-1">Wait time</Label>
+                <Select value={String(data.wait_minutes)} onValueChange={(v) => setData('wait_minutes', Number(v))}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Wait time" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {waitMinutesOptions.map((minutes) => (
+                      <SelectItem key={minutes} value={String(minutes)}>{minutes} minutes</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {errors.wait_minutes && <div className="text-red font-bold mt-1 text-sm">{errors.wait_minutes}</div>}
+              </div>
+
+              <div className="w-full md:w-1/2">
+                <Label className="block mb-1">Requires approval</Label>
+                <div className="flex gap-2" role="radiogroup" aria-label="Requires approval">
+                  <Button
+                    type="button"
+                    role="radio"
+                    aria-checked={!data.requires_approval}
+                    variant={!data.requires_approval ? 'default' : 'neutral'}
+                    onClick={() => setData('requires_approval', false)}
+                  >
+                    No
+                  </Button>
+                  <Button
+                    type="button"
+                    role="radio"
+                    aria-checked={data.requires_approval}
+                    variant={data.requires_approval ? 'default' : 'neutral'}
+                    onClick={() => setData('requires_approval', true)}
+                  >
+                    Yes
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            <div className="w-full">
+              <Label htmlFor="goal" className="block mb-1">Goal</Label>
+              <Textarea
+                id="goal"
+                value={data.goal}
+                onChange={e => setData('goal', e.target.value)}
+                rows="3"
+              />
+              {errors.goal && <div className="text-red font-bold mt-1 text-sm">{errors.goal}</div>}
+            </div>
+
+            <div className="flex flex-col gap-4 md:flex-row">
+              <div className="w-full md:w-1/2">
+                <Label className="block mb-1">Platform</Label>
+                <Select value={data.platform} onValueChange={(v) => setData('platform', v)}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Platform" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {platformOptions.map((platform) => (
+                      <SelectItem key={platform} value={platform}>{humanize(platform)}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {errors.platform && <div className="text-red font-bold mt-1 text-sm">{errors.platform}</div>}
+              </div>
+
+              <div className="w-full md:w-1/2">
+                <Label htmlFor="pairing_tool" className="block mb-1">Pairing tool <span className="text-xs font-normal">(optional)</span></Label>
+                <Input
+                  id="pairing_tool"
+                  type="text"
+                  value={data.pairing_tool}
+                  onChange={e => setData('pairing_tool', e.target.value)}
+                />
+                {errors.pairing_tool && <div className="text-red font-bold mt-1 text-sm">{errors.pairing_tool}</div>}
+              </div>
+            </div>
+
+            <div className="w-full">
+              <Label htmlFor="plan" className="block mb-1">Plan <span className="text-xs font-normal">(optional)</span></Label>
+              <Textarea
+                id="plan"
+                value={data.plan}
+                onChange={e => setData('plan', e.target.value)}
+                rows="3"
+              />
+              {errors.plan && <div className="text-red font-bold mt-1 text-sm">{errors.plan}</div>}
+            </div>
+          </div>
+        )}
+
+        <div className={`mt-8 grid grid-cols-1 gap-6 ${data.mode === 'scheduled' ? 'md:grid-cols-2' : ''}`}>
+          {data.mode === 'scheduled' && (
           <div>
             <h4 className="mb-3 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Periods</h4>
 
@@ -193,6 +333,7 @@ export default function New({ tags }) {
               + Add period
             </Button>
           </div>
+          )}
 
           <div>
             <h4 className="mb-3 font-headline text-sm font-bold uppercase tracking-widest text-black/50">Tags</h4>

--- a/app/javascript/pages/Users/PairRequests/TagCombobox.jsx
+++ b/app/javascript/pages/Users/PairRequests/TagCombobox.jsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+export default function TagCombobox({ tags, value, onChange }) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = tags.filter((tag) => tag.label.toLowerCase().includes(search.toLowerCase()));
+  const exactMatch = tags.some((tag) => tag.label.toLowerCase() === search.trim().toLowerCase());
+
+  const select = (name) => {
+    onChange(name);
+    setSearch("");
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="neutral"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn("truncate", !value && "text-black/40")}>
+            {value || "Search or create..."}
+          </span>
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] bg-secondary-background p-0 text-foreground"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput value={search} onValueChange={setSearch} placeholder="Search or create..." />
+          <CommandList>
+            {filtered.length === 0 && <CommandEmpty>No matching tags.</CommandEmpty>}
+            <CommandGroup>
+              {filtered.map((tag) => (
+                <CommandItem key={tag.value} value={tag.label} onSelect={() => select(tag.label)}>
+                  <Check className={cn("h-4 w-4", value === tag.label ? "opacity-100" : "opacity-0")} />
+                  {tag.label}
+                </CommandItem>
+              ))}
+              {search.trim() && !exactMatch && (
+                <CommandItem value={search} onSelect={() => select(search.trim())}>
+                  <Plus className="h-4 w-4" />
+                  Create "{search.trim()}"
+                </CommandItem>
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/resources/pair_request_browse_resource.rb
+++ b/app/resources/pair_request_browse_resource.rb
@@ -1,0 +1,23 @@
+class PairRequestBrowseResource < ApplicationResource
+  attributes :id, :subject, :description, :goal, :platform
+
+  many :tags, resource: TagResource
+
+  attribute :periods do |pair_request|
+    pair_request.periods.map { |period| { id: period.id, start_at: period.start_at, end_at: period.end_at } }
+  end
+
+  attribute :user do |pair_request|
+    user = pair_request.user
+    {
+      name: user.name,
+      profession: user.profession,
+      image_url: user.image_url,
+      level_titleized: user.level_titleized
+    }
+  end
+
+  attribute :offers do |pair_request|
+    pair_request.offers.map { |offer| { offerer_id: offer.offerer_id } }
+  end
+end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@stimulus-components/read-more": "^5.0.0",
     "@stimulus-components/reveal": "^5.0.0",
     "@tailwindcss/forms": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "autoprefixer": "^10.4.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.3.0",
     "esbuild": "^0.19.7",
     "flatpickr": "^4.6.13",

--- a/spec/system/pair_requests/index_spec.rb
+++ b/spec/system/pair_requests/index_spec.rb
@@ -29,4 +29,19 @@ RSpec.describe "display pair requests", type: :system do
       expect(page).to have_content("You have already sent an offer")
     end
   end
+
+  context "when another user has an immediate pair request live now" do
+    let!(:live_pair_request) do
+      pair_request = create(:pair_request, :immediate, subject: "GGG", description: "HHH", with_periods: false)
+      create(:period, periodable: pair_request, start_at: Time.current)
+      pair_request
+    end
+
+    it "displays it in the Live now section" do
+      visit pair_requests_path
+
+      expect(page).to have_content("Live now")
+      expect(page).to have_content("GGG")
+    end
+  end
 end

--- a/spec/system/users/pair_requests/create_spec.rb
+++ b/spec/system/users/pair_requests/create_spec.rb
@@ -38,4 +38,30 @@ RSpec.describe "users pair requests", type: :system do
       end
     end
   end
+
+  context "when mode is immediate" do
+    it "creates a pair request with a single period starting now, ignoring any scheduled periods" do
+      visit new_users_pair_request_path
+
+      fill_in "Subject", with: "AAA"
+      fill_in "Description", with: "BBB"
+      fill_in "Duration", with: 45
+      pick_future_period!
+
+      click_button "Immediate"
+      fill_in "Goal", with: "Pair on a tricky bug"
+      select_option! "Wait time", "30 minutes"
+      select_option! "Platform", "Zoom"
+
+      click_button "Create Pair request"
+
+      expect(page).to have_content("AAA")
+
+      pair_request = current_user.pair_requests.find_by!(subject: "AAA")
+
+      expect(pair_request.mode).to eq("immediate")
+      expect(pair_request.periods.count).to eq(1)
+      expect(pair_request.periods.first.start_at).to be_within(5.seconds).of(Time.current)
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,7 +1046,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
 
-"@radix-ui/react-compose-refs@1.1.5":
+"@radix-ui/react-compose-refs@1.1.5", "@radix-ui/react-compose-refs@^1.1.1":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz#883e642c5ec0ba393dd1bf586e7e772985770d87"
   integrity sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==
@@ -1098,6 +1098,27 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-dialog@^1.1.6":
+  version "1.1.23"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz#b7d8e83a3ccf97e46f3c3f477a0bf563f0de8239"
+  integrity sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.5"
+    "@radix-ui/react-context" "1.2.2"
+    "@radix-ui/react-dismissable-layer" "1.1.19"
+    "@radix-ui/react-focus-guards" "1.1.6"
+    "@radix-ui/react-focus-scope" "1.1.16"
+    "@radix-ui/react-id" "1.1.4"
+    "@radix-ui/react-portal" "1.1.17"
+    "@radix-ui/react-presence" "1.1.10"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-slot" "1.3.3"
+    "@radix-ui/react-use-controllable-state" "1.2.6"
+    "@radix-ui/react-use-layout-effect" "1.1.4"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
 "@radix-ui/react-direction@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
@@ -1119,6 +1140,17 @@
     "@radix-ui/react-use-callback-ref" "1.1.1"
     "@radix-ui/react-use-escape-keydown" "1.1.1"
 
+"@radix-ui/react-dismissable-layer@1.1.19":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz#ef64a08943bdf04e00996f55472456353014fa68"
+  integrity sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==
+  dependencies:
+    "@radix-ui/primitive" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-use-callback-ref" "1.1.4"
+    "@radix-ui/react-use-effect-event" "0.0.5"
+
 "@radix-ui/react-dropdown-menu@2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz#5ee045c62bad8122347981c479d92b1ff24c7254"
@@ -1136,6 +1168,20 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz#2a5669e464ad5fde9f86d22f7fdc17781a4dfa7f"
   integrity sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==
+
+"@radix-ui/react-focus-guards@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz#853985fb77fb7f6f65ab2e4750d1cfde9c702e36"
+  integrity sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==
+
+"@radix-ui/react-focus-scope@1.1.16":
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz#1221498b222efaae678a25ae4b81025c5feda195"
+  integrity sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-use-callback-ref" "1.1.4"
 
 "@radix-ui/react-focus-scope@1.1.7":
   version "1.1.7"
@@ -1180,7 +1226,7 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
-"@radix-ui/react-id@1.1.4":
+"@radix-ui/react-id@1.1.4", "@radix-ui/react-id@^1.1.0":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.4.tgz#e642714bdaf551c1bfacbe51508ed843a3a27980"
   integrity sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==
@@ -1330,6 +1376,14 @@
     "@radix-ui/react-use-size" "1.1.1"
     "@radix-ui/rect" "1.1.1"
 
+"@radix-ui/react-portal@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.17.tgz#f3b60bb5d78f12143e17553c45ed0506b026ec18"
+  integrity sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-use-layout-effect" "1.1.4"
+
 "@radix-ui/react-portal@1.1.9":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
@@ -1353,7 +1407,7 @@
     "@radix-ui/react-compose-refs" "1.1.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
-"@radix-ui/react-primitive@2.1.10":
+"@radix-ui/react-primitive@2.1.10", "@radix-ui/react-primitive@^2.0.2":
   version "2.1.10"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz#292b7476499d17227f337c8d1c59f270c683842a"
   integrity sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==
@@ -2290,6 +2344,16 @@ clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
+cmdk@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "^1.1.1"
+    "@radix-ui/react-dialog" "^1.1.6"
+    "@radix-ui/react-id" "^1.1.0"
+    "@radix-ui/react-primitive" "^2.0.2"
 
 code-block-writer@^13.0.3:
   version "13.0.3"
@@ -3962,7 +4026,7 @@ react-remove-scroll-bar@^2.3.7:
     react-style-singleton "^2.2.2"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.6.3:
+react-remove-scroll@^2.6.3, react-remove-scroll@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
   integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
   integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
 
+"@radix-ui/primitive@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.7.tgz#0d0929d20299f60b0cd8a0deafad79f8048f9306"
+  integrity sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==
+
 "@radix-ui/react-accessible-icon@1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz#3b1629ce0c5ce0f791a21e28cfa6a1ffb82e2029"
@@ -1016,6 +1021,16 @@
     "@radix-ui/react-use-controllable-state" "1.2.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-collection@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.15.tgz#6f045630d6f9778ab1b0c456ae97b474aec8a20b"
+  integrity sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.5"
+    "@radix-ui/react-context" "1.2.2"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-slot" "1.3.3"
+
 "@radix-ui/react-collection@1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
@@ -1030,6 +1045,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
+"@radix-ui/react-compose-refs@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz#883e642c5ec0ba393dd1bf586e7e772985770d87"
+  integrity sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==
 
 "@radix-ui/react-context-menu@2.2.16":
   version "2.2.16"
@@ -1052,6 +1072,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
   integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
+
+"@radix-ui/react-context@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.2.2.tgz#fe2548e98465f5f9b776c5953de35d04a8919b6b"
+  integrity sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==
 
 "@radix-ui/react-dialog@1.1.15":
   version "1.1.15"
@@ -1077,6 +1102,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
   integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
+
+"@radix-ui/react-direction@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.4.tgz#e7b7049f3c3ab8e6e014c4600f9f1974a52c05f1"
+  integrity sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==
 
 "@radix-ui/react-dismissable-layer@1.1.11":
   version "1.1.11"
@@ -1149,6 +1179,13 @@
   integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-id@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.4.tgz#e642714bdaf551c1bfacbe51508ed843a3a27980"
+  integrity sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.4"
 
 "@radix-ui/react-label@2.1.7":
   version "2.1.7"
@@ -1301,6 +1338,13 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-presence@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.10.tgz#49041cb9c41c3e8d1791d6b96a1d3bcd8429a151"
+  integrity sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.4"
+
 "@radix-ui/react-presence@1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
@@ -1308,6 +1352,13 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-primitive@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz#292b7476499d17227f337c8d1c59f270c683842a"
+  integrity sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==
+  dependencies:
+    "@radix-ui/react-slot" "1.3.3"
 
 "@radix-ui/react-primitive@2.1.3":
   version "2.1.3"
@@ -1369,6 +1420,23 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-callback-ref" "1.1.1"
     "@radix-ui/react-use-controllable-state" "1.2.2"
+
+"@radix-ui/react-roving-focus@1.1.19":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz#2abc0676448f4ebae8c43a61f9531aebe0f5c823"
+  integrity sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.7"
+    "@radix-ui/react-collection" "1.1.15"
+    "@radix-ui/react-compose-refs" "1.1.5"
+    "@radix-ui/react-context" "1.2.2"
+    "@radix-ui/react-direction" "1.1.4"
+    "@radix-ui/react-id" "1.1.4"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-use-callback-ref" "1.1.4"
+    "@radix-ui/react-use-controllable-state" "1.2.6"
+    "@radix-ui/react-use-is-hydrated" "0.1.3"
+    "@radix-ui/react-use-layout-effect" "1.1.4"
 
 "@radix-ui/react-scroll-area@1.2.10":
   version "1.2.10"
@@ -1450,6 +1518,13 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
+"@radix-ui/react-slot@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.3.3.tgz#ccc8c8936fff12f7e324d6917fe5167357097676"
+  integrity sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.5"
+
 "@radix-ui/react-switch@1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.2.6.tgz#ff79acb831f0d5ea9216cfcc5b939912571358e3"
@@ -1476,6 +1551,20 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-roving-focus" "1.1.11"
     "@radix-ui/react-use-controllable-state" "1.2.2"
+
+"@radix-ui/react-tabs@^1.1.13":
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz#db7eb9b33f25d645a6a21028e9e0047d457c49a0"
+  integrity sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==
+  dependencies:
+    "@radix-ui/primitive" "1.1.7"
+    "@radix-ui/react-context" "1.2.2"
+    "@radix-ui/react-direction" "1.1.4"
+    "@radix-ui/react-id" "1.1.4"
+    "@radix-ui/react-presence" "1.1.10"
+    "@radix-ui/react-primitive" "2.1.10"
+    "@radix-ui/react-roving-focus" "1.1.19"
+    "@radix-ui/react-use-controllable-state" "1.2.6"
 
 "@radix-ui/react-toast@1.2.15":
   version "1.2.15"
@@ -1553,6 +1642,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
   integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
 
+"@radix-ui/react-use-callback-ref@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz#1e55d37148e60a3f47de4bc7ea7cff6fa3f425ae"
+  integrity sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==
+
 "@radix-ui/react-use-controllable-state@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
@@ -1561,12 +1655,28 @@
     "@radix-ui/react-use-effect-event" "0.0.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-use-controllable-state@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz#0f109eff004c3c1ff5f9709570f45dee9955513e"
+  integrity sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.7"
+    "@radix-ui/react-use-effect-event" "0.0.5"
+    "@radix-ui/react-use-layout-effect" "1.1.4"
+
 "@radix-ui/react-use-effect-event@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
   integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz#7732a4ae6bc032c7f654e658203df92d3520f8d1"
+  integrity sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.4"
 
 "@radix-ui/react-use-escape-keydown@1.1.1":
   version "1.1.1"
@@ -1582,10 +1692,20 @@
   dependencies:
     use-sync-external-store "^1.5.0"
 
+"@radix-ui/react-use-is-hydrated@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz#f0ffa47394726046ba6c6d0b7c97239f48c8df45"
+  integrity sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==
+
 "@radix-ui/react-use-layout-effect@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
   integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
+"@radix-ui/react-use-layout-effect@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz#51a0bbc342315070983383b3f8f00061083782a8"
+  integrity sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==
 
 "@radix-ui/react-use-previous@1.1.1":
   version "1.1.1"


### PR DESCRIPTION
## Summary
Implements #89 (immediate-mode request creation + live/scheduled browse split), end to end without real-time refresh (manual reload only), per the plan in `docs/immediate-pairing-implementation-plan.md`.

- `Users::PairRequestsController#create` accepts `mode`, `wait_minutes`, `requires_approval`, `goal`, `platform`, `pairing_tool`, `plan`. For `mode: "immediate"`, it ignores any client-sent periods and builds a single server-side `Period` at `Time.current`.
- `Users/PairRequests/New.jsx` gets a mode toggle (scheduled/immediate). Immediate mode hides the periods fieldset and shows wait time, requires-approval, goal, platform, pairing tool, and plan fields.
- `PairRequestsController#index` renders `livePairRequests` (from `live_now`, unpaginated) and `scheduledPairRequests` (existing Ransack+Pagy+scroll, from the renamed `scheduled_active` scope) as separate props.
- `PairRequests/Index.jsx`/`Card.jsx` render a "Live now" section above "Scheduled" — display-only, no join action yet (that's a later issue in the plan).

## Review notes
Ran `/code-review` before committing. Two "major" findings were the issue's explicit scope (no join button yet on live cards; several new fields like `requires_approval` aren't consumed until later issues) so left as-is. Fixed three real findings: missing `.distinct` on the live-requests query, toggle buttons missing `aria-pressed`/`role="radio"` semantics, and immediate-only fields no longer leak as empty strings when submitting in scheduled mode. A pre-existing gap (scheduled requests can be saved with zero periods) was flagged but is unrelated to this branch's diff, so left out of scope.

## Test plan
- [x] `bundle exec rspec` — 94 examples, 0 failures
- [x] New system specs: immediate creation persists a single `Period` at `Time.current` regardless of submitted periods; immediate request appears in another user's "Live now" list
- [x] Manual QA in browser (create immediate request, confirm it shows in another user's live list; create scheduled request, confirm unaffected)
