### PR TITLE
Session retro submission (#90)

### DIFF
--- a/app/controllers/session_feedbacks_controller.rb
+++ b/app/controllers/session_feedbacks_controller.rb
@@ -1,0 +1,40 @@
+class SessionFeedbacksController < ApplicationController
+  include Authenticated
+
+  def new
+    @session = Session.find(params[:session_id])
+    @session_feedback = @session.session_feedbacks.build(participant: current_user)
+
+    authorize @session_feedback
+
+    render inertia: "SessionFeedbacks/New", props: {
+      sessionId: @session.id,
+      subject: @session.sessionable.subject,
+      otherParticipantName: @session.other_participant(current_user)&.name,
+      wentWellValues: SessionFeedback::WENT_WELL_VALUES
+    }
+  end
+
+  def create
+    @session = Session.find(session_feedback_params[:session_id])
+    @session_feedback = @session.session_feedbacks.build(
+      session_feedback_params.except(:session_id).merge(participant: current_user)
+    )
+
+    authorize @session_feedback
+
+    if @session_feedback.save
+      redirect_to sessions_path, notice: "Thanks for sharing your retro!"
+    else
+      redirect_to new_session_feedback_path(session_id: @session.id), inertia: { errors: @session_feedback.errors.to_hash(true) }
+    end
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to sessions_path, alert: "You've already submitted feedback for this session."
+  end
+
+  private
+
+  def session_feedback_params
+    params.require(:session_feedback).permit(:session_id, :went_well, :learned, :notes, :code_snippet, :code_snippet_language)
+  end
+end

--- a/app/javascript/pages/SessionFeedbacks/New.jsx
+++ b/app/javascript/pages/SessionFeedbacks/New.jsx
@@ -39,6 +39,12 @@ export default function New({ sessionId, subject, otherParticipantName, wentWell
               </div>
             )}
 
+            {errors.session && (
+              <div className="mb-4 rounded-xl border-2 border-black bg-orange/10 p-3 text-sm font-bold">
+                This session {errors.session}.
+              </div>
+            )}
+
             <div className="w-full">
               <Label className="block mb-1">How did it go?</Label>
               <input type="hidden" name="went_well" value={wentWell} />

--- a/app/javascript/pages/SessionFeedbacks/New.jsx
+++ b/app/javascript/pages/SessionFeedbacks/New.jsx
@@ -1,0 +1,109 @@
+import { Form, Head } from '@inertiajs/react';
+import { useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+const WENT_WELL_EMOJI = {
+  great: "🎉",
+  good: "🙂",
+  okay: "😐",
+  tough: "😓"
+};
+
+const humanize = (value) => value.charAt(0).toUpperCase() + value.slice(1);
+
+export default function New({ sessionId, subject, otherParticipantName, wentWellValues }) {
+  const [wentWell, setWentWell] = useState("");
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 pb-16 md:px-8">
+      <Head title="Session retro" />
+
+      <PageHeader
+        eyebrow="Retro"
+        title={subject || "How did it go?"}
+        description={otherParticipantName ? `Share a private retro on your session with ${otherParticipantName}. Only you and your partner can see this.` : "Share a private retro on this session."}
+      />
+
+      <Form method="post" action="/session_feedbacks" className="flex flex-col items-stretch">
+        {({ errors, processing }) => (
+          <>
+            <input type="hidden" name="session_id" value={sessionId} />
+
+            {errors.participant_id && (
+              <div className="mb-4 rounded-xl border-2 border-black bg-orange/10 p-3 text-sm font-bold">
+                You've already submitted feedback for this session.
+              </div>
+            )}
+
+            <div className="w-full">
+              <Label className="block mb-1">How did it go?</Label>
+              <input type="hidden" name="went_well" value={wentWell} />
+              <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="How did it go?">
+                {wentWellValues.map((value) => (
+                  <Button
+                    key={value}
+                    type="button"
+                    role="radio"
+                    aria-checked={wentWell === value}
+                    variant={wentWell === value ? "default" : "neutral"}
+                    onClick={() => setWentWell(value)}
+                  >
+                    <span className="mr-1.5">{WENT_WELL_EMOJI[value]}</span>
+                    {humanize(value)}
+                  </Button>
+                ))}
+              </div>
+              {errors.went_well && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.went_well}</div>
+              )}
+            </div>
+
+            <div className="w-full mt-4">
+              <Label htmlFor="learned" className="block mb-1">What did you learn?</Label>
+              <Textarea id="learned" name="learned" rows="4" className="w-full" />
+              {errors.learned && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.learned}</div>
+              )}
+            </div>
+
+            <div className="w-full mt-4">
+              <Label htmlFor="notes" className="block mb-1">Notes</Label>
+              <Textarea id="notes" name="notes" rows="4" className="w-full" />
+              {errors.notes && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.notes}</div>
+              )}
+            </div>
+
+            <div className="w-full mt-4">
+              <Label htmlFor="code_snippet" className="block mb-1">
+                Code <span className="text-xs font-normal">(paste a GitHub link or a snippet, optional)</span>
+              </Label>
+              <Textarea id="code_snippet" name="code_snippet" rows="4" className="w-full" />
+              {errors.code_snippet && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.code_snippet}</div>
+              )}
+            </div>
+
+            <div className="w-full mt-4">
+              <Label htmlFor="code_snippet_language" className="block mb-1">
+                Code language <span className="text-xs font-normal">(optional)</span>
+              </Label>
+              <Input id="code_snippet_language" name="code_snippet_language" className="w-full" />
+              {errors.code_snippet_language && (
+                <div className="text-red font-bold mt-1 text-sm">{errors.code_snippet_language}</div>
+              )}
+            </div>
+
+            <Button type="submit" size="lg" disabled={processing} className="mt-10 self-center">
+              {processing ? "Sending..." : "Submit retro"}
+            </Button>
+          </>
+        )}
+      </Form>
+    </div>
+  );
+}

--- a/app/models/session_feedback.rb
+++ b/app/models/session_feedback.rb
@@ -8,4 +8,13 @@ class SessionFeedback < ApplicationRecord
 
   validates :went_well, inclusion: { in: WENT_WELL_VALUES }, allow_blank: true
   validates :participant_id, uniqueness: { scope: :session_id }
+  validate :session_has_ended
+
+  private
+
+  def session_has_ended
+    return if session.blank? || session.end_at.blank?
+
+    errors.add(:session, "hasn't ended yet - you can leave feedback once it's over") if session.end_at > Time.current
+  end
 end

--- a/app/models/session_feedback.rb
+++ b/app/models/session_feedback.rb
@@ -1,4 +1,6 @@
 class SessionFeedback < ApplicationRecord
+  include ActivityGeneratable
+
   WENT_WELL_VALUES = %w(great good okay tough).freeze
 
   belongs_to :session

--- a/app/models/session_feedback.rb
+++ b/app/models/session_feedback.rb
@@ -6,6 +6,6 @@ class SessionFeedback < ApplicationRecord
   belongs_to :session
   belongs_to :participant, class_name: "User"
 
-  validates :went_well, inclusion: { in: WENT_WELL_VALUES }, allow_nil: true
+  validates :went_well, inclusion: { in: WENT_WELL_VALUES }, allow_blank: true
   validates :participant_id, uniqueness: { scope: :session_id }
 end

--- a/app/policies/session_feedback_policy.rb
+++ b/app/policies/session_feedback_policy.rb
@@ -1,0 +1,5 @@
+class SessionFeedbackPolicy < ApplicationPolicy
+  def create?
+    record.session.participants.include?(user)
+  end
+end

--- a/app/services/activities_setup/from_session_feedback.rb
+++ b/app/services/activities_setup/from_session_feedback.rb
@@ -1,0 +1,32 @@
+module ActivitiesSetup
+  class FromSessionFeedback
+    attr_reader :record, :previous_changes
+    private :record, :previous_changes
+
+    def initialize(record, previous_changes)
+      @record = record
+      @previous_changes = previous_changes
+    end
+
+    def self.call(...) = new(...).call
+
+    def call
+      return unless previously_created?
+
+      other_participant = record.session.other_participant(record.participant)
+      return unless other_participant
+
+      Activity.create!(
+        receiver: other_participant,
+        title: I18n.t("activities.session_feedback_received.titles").sample,
+        content: I18n.t("activities.session_feedback_received.content").sample
+      )
+    end
+
+    private
+
+    def previously_created?
+      previous_changes.key?(:id)
+    end
+  end
+end

--- a/config/locales/activities/en.yml
+++ b/config/locales/activities/en.yml
@@ -119,3 +119,12 @@ en:
         - Your pair request is now live!
       content:
         - Thanks for keeping community alive. Hope you'll get first responses soon!
+    session_feedback_received:
+      titles:
+        - Your partner left feedback!
+        - New retro notes from your pairing partner!
+        - Your partner shared their session retro!
+      content:
+        - Your partner just left feedback on your last session. Take a look and see what they thought!
+        - There's new retro feedback waiting for you from your pairing partner.
+        - Your pairing partner shared their thoughts on your last session together. Check it out!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,7 @@ Rails.application.routes.draw do
     resources :offers, only: [:index]
   end
 
+  resources :session_feedbacks, only: [:new, :create]
+
   resources :activities, only: [:index]
 end

--- a/spec/factories/session_feedbacks.rb
+++ b/spec/factories/session_feedbacks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:session_feedback) do
-    session
+    association :session, :past
     participant factory: :user
 
     went_well { SessionFeedback::WENT_WELL_VALUES.sample }

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -9,6 +9,14 @@ FactoryBot.define do
     start_at { 45.minutes.from_now }
     end_at { 115.minutes.from_now }
 
+    # Session validates dates_in_future on save, so a truly past session can't be
+    # built via normal attributes - it always starts out scheduled in the future,
+    # then backdated afterward with update_columns (bypasses validations/callbacks)
+    # to simulate one that has already happened.
+    trait :past do
+      after(:create) { |session| session.update_columns(start_at: 2.hours.ago, end_at: 1.hour.ago) }
+    end
+
     after(:create) do |session, evaluator|
       if evaluator.with_holder || evaluator.with_partner
         pair_request = session.sessionable

--- a/spec/models/session_feedback_spec.rb
+++ b/spec/models/session_feedback_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe SessionFeedback, type: :model do
         expect(session_feedback).to be_valid
       end
 
+      it "allows an empty string (the unselected state the form submits)" do
+        session_feedback.went_well = ""
+
+        expect(session_feedback).to be_valid
+      end
+
       it "allows values in the allowed set" do
         session_feedback.went_well = "great"
 

--- a/spec/models/session_feedback_spec.rb
+++ b/spec/models/session_feedback_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe SessionFeedback, type: :model do
   describe "validations" do
     describe "went_well" do
-      let(:session_feedback) { build(:session_feedback) }
+      let(:session_feedback) { build(:session_feedback, session: create(:session, :past)) }
 
       it "allows nil" do
         session_feedback.went_well = nil
@@ -30,7 +30,7 @@ RSpec.describe SessionFeedback, type: :model do
     end
 
     describe "participant_id uniqueness scoped to session_id" do
-      let(:session) { create(:session) }
+      let(:session) { create(:session, :past) }
       let(:participant) { create(:user) }
 
       before { create(:session_feedback, session:, participant:) }
@@ -43,10 +43,25 @@ RSpec.describe SessionFeedback, type: :model do
       end
 
       it "allows the same participant to leave feedback for a different session" do
-        other_session = create(:session)
+        other_session = create(:session, :past)
         other_feedback = build(:session_feedback, session: other_session, participant:)
 
         expect(other_feedback).to be_valid
+      end
+    end
+
+    describe "session must have ended" do
+      it "is valid when the session has already ended" do
+        session_feedback = build(:session_feedback, session: create(:session, :past))
+
+        expect(session_feedback).to be_valid
+      end
+
+      it "is invalid when the session hasn't ended yet" do
+        session_feedback = build(:session_feedback, session: create(:session))
+
+        expect(session_feedback).to be_invalid
+        expect(session_feedback.errors[:session]).to be_present
       end
     end
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Session, type: :model do
   describe "#feedback_from" do
     subject(:feedback_from) { session.feedback_from(participant) }
 
-    let(:session) { create(:session, with_holder: false, with_partner: false) }
+    let(:session) { create(:session, :past, with_holder: false, with_partner: false) }
     let(:participant) { create(:user) }
 
     context "when participant left feedback" do
@@ -112,7 +112,7 @@ RSpec.describe Session, type: :model do
   describe "#feedback_complete?" do
     subject(:feedback_complete?) { session.feedback_complete? }
 
-    let(:session) { create(:session, with_holder: false, with_partner: false) }
+    let(:session) { create(:session, :past, with_holder: false, with_partner: false) }
     let(:participant_1) { create(:user) }
     let(:participant_2) { create(:user) }
     let!(:participation_1) { create(:participation, participable: session, participant: participant_1) }

--- a/spec/services/activities_setup/from_session_feedback_spec.rb
+++ b/spec/services/activities_setup/from_session_feedback_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe ActivitiesSetup::FromSessionFeedback, type: :unit do
+  describe ".call" do
+    subject(:call) { described_class.call(record, previous_changes) }
+
+    let(:record) { create(:session_feedback, session: session, participant: participant) }
+    let(:session) { create(:session) }
+    let(:participant) { session.participants.first }
+    let(:other_participant) { session.other_participant(participant) }
+    let(:previous_changes) { changes }
+
+    context "when record created" do
+      let(:changes) { { id: [nil, "1"] } }
+
+      it "creates an activity for the other participant" do
+        expect { call }.to change { Activity.count }.by(1)
+
+        expect(Activity.last).to have_attributes(
+          receiver_id: other_participant.id,
+          title: in_array(I18n.t("activities.session_feedback_received.titles")),
+          content: in_array(I18n.t("activities.session_feedback_received.content"))
+        )
+      end
+    end
+
+    context "when record not created" do
+      let(:changes) { { updated_at: [nil, Time.current] } }
+
+      it "doesn't create an activity" do
+        expect { call }.not_to change { Activity.count }
+      end
+    end
+  end
+end

--- a/spec/services/activities_setup/from_session_feedback_spec.rb
+++ b/spec/services/activities_setup/from_session_feedback_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ActivitiesSetup::FromSessionFeedback, type: :unit do
     subject(:call) { described_class.call(record, previous_changes) }
 
     let(:record) { create(:session_feedback, session: session, participant: participant) }
-    let(:session) { create(:session) }
+    let(:session) { create(:session, :past) }
     let(:participant) { session.participants.first }
     let(:other_participant) { session.other_participant(participant) }
     let(:previous_changes) { changes }

--- a/spec/services/activities_setup/proxy_spec.rb
+++ b/spec/services/activities_setup/proxy_spec.rb
@@ -33,5 +33,15 @@ RSpec.describe ActivitiesSetup::Proxy, type: :unit do
         call
       end
     end
+
+    context "when record is SessionFeedback" do
+      let(:record) { build(:session_feedback) }
+
+      it "calls expected service" do
+        expect(ActivitiesSetup::FromSessionFeedback).to receive(:call).with(record, previous_changes)
+
+        call
+      end
+    end
   end
 end

--- a/spec/system/activities/generation_spec.rb
+++ b/spec/system/activities/generation_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "generates expected activites", type: :system do
   end
 
   context "when session feedback submitted" do
-    let(:session) { create(:session, with_holder: false) }
+    let(:session) { create(:session, :past, with_holder: false) }
     let!(:current_user_participation) { create(:participation, participable: session, participant: current_user) }
     let(:other_participant) { session.other_participant(current_user) }
 

--- a/spec/system/activities/generation_spec.rb
+++ b/spec/system/activities/generation_spec.rb
@@ -83,6 +83,23 @@ RSpec.describe "generates expected activites", type: :system do
     end
   end
 
+  context "when session feedback submitted" do
+    let(:session) { create(:session, with_holder: false) }
+    let!(:current_user_participation) { create(:participation, participable: session, participant: current_user) }
+    let(:other_participant) { session.other_participant(current_user) }
+
+    it "displays expected activity" do
+      perform_enqueued_jobs do
+        create(:session_feedback, session: session, participant: other_participant)
+      end
+
+      visit activities_path
+
+      expect(page).to have_one_of_the_texts(I18n.t("activities.session_feedback_received.titles"))
+      expect(page).to have_one_of_the_texts(I18n.t("activities.session_feedback_received.content"))
+    end
+  end
+
   context "when offer rejected" do
     let(:pair_request) { create(:pair_request) }
     let(:current_user_offer) { build(:offer, offerer: current_user, pair_request:) }

--- a/spec/system/session_feedbacks/create_spec.rb
+++ b/spec/system/session_feedbacks/create_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe "submit session feedback", type: :system do
       expect(feedback.learned).to eq("Learned a ton about pairing")
     end
 
+    it "allows submitting without picking a reaction" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      fill_in "Notes", with: "No strong reaction, just some notes"
+      click_button "Submit retro"
+
+      expect(page).to have_content("Thanks for sharing your retro!")
+
+      feedback = session.session_feedbacks.find_by!(participant: current_user)
+      expect(feedback.went_well).to be_blank
+      expect(feedback.notes).to eq("No strong reaction, just some notes")
+    end
+
     context "when feedback was already submitted for this session" do
       let!(:existing_feedback) { create(:session_feedback, session: session, participant: current_user) }
 

--- a/spec/system/session_feedbacks/create_spec.rb
+++ b/spec/system/session_feedbacks/create_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "submit session feedback", type: :system do
   before { sign_in(current_user) }
 
   context "when current user is a participant" do
-    let(:session) { create(:session, with_holder: false) }
+    let(:session) { create(:session, :past, with_holder: false) }
     let!(:participation) { create(:participation, participable: session, participant: current_user) }
 
     it "creates a session feedback for the current user" do
@@ -56,6 +56,21 @@ RSpec.describe "submit session feedback", type: :system do
       visit new_session_feedback_path(session_id: session.id)
 
       expect(page).to have_content("Not authorized for this action")
+    end
+  end
+
+  context "when the session hasn't ended yet" do
+    let(:session) { create(:session, with_holder: false) }
+    let!(:participation) { create(:participation, participable: session, participant: current_user) }
+
+    it "rejects the submission cleanly" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      click_button "Great"
+      click_button "Submit retro"
+
+      expect(page).to have_content("hasn't ended yet")
+      expect(session.session_feedbacks.count).to eq(0)
     end
   end
 end

--- a/spec/system/session_feedbacks/create_spec.rb
+++ b/spec/system/session_feedbacks/create_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe "submit session feedback", type: :system do
+  let(:current_user) { create(:user) }
+  let(:session) { create(:session) }
+
+  before { sign_in(current_user) }
+
+  context "when current user is a participant" do
+    let(:session) { create(:session, with_holder: false) }
+    let!(:participation) { create(:participation, participable: session, participant: current_user) }
+
+    it "creates a session feedback for the current user" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      click_button "Great"
+      fill_in "What did you learn?", with: "Learned a ton about pairing"
+
+      click_button "Submit retro"
+
+      expect(page).to have_content("Thanks for sharing your retro!")
+
+      feedback = session.session_feedbacks.find_by!(participant: current_user)
+      expect(feedback.went_well).to eq("great")
+      expect(feedback.learned).to eq("Learned a ton about pairing")
+    end
+
+    context "when feedback was already submitted for this session" do
+      let!(:existing_feedback) { create(:session_feedback, session: session, participant: current_user) }
+
+      it "rejects the duplicate submission cleanly" do
+        visit new_session_feedback_path(session_id: session.id)
+
+        click_button "Good"
+        click_button "Submit retro"
+
+        expect(page).to have_content("already submitted feedback")
+        expect(session.session_feedbacks.where(participant: current_user).count).to eq(1)
+      end
+    end
+  end
+
+  context "when current user is not a participant of the session" do
+    it "is not authorized" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      expect(page).to have_content("Not authorized for this action")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds post-session retro submission end to end: `SessionFeedbacksController#new`/`#create`, `SessionFeedbackPolicy`, and `SessionFeedbacks/New.jsx` (Form render-prop pattern, emoji reaction row via local state + hidden input).
- Submitting feedback notifies the other participant via the existing `ActivityGeneratable`/`ActivitiesSetup::From*` pipeline (new `ActivitiesSetup::FromSessionFeedback`, new `en.activities.session_feedback_received` locale copy).
- Double-submit is rejected with a friendly banner instead of a 500 (`participant_id` uniqueness scoped to `session_id`), and only session participants can submit for that session.
- Fixes a bug found while testing: `went_well` used `allow_nil`, but the forms hidden input always sends an empty string when unselected, making the optional reaction field effectively required. Switched to `allow_blank`, matching the existing `PairRequest#platform` convention for the same situation.

Closes #90.

## Test plan
- [x] `bundle exec rspec` (model, service, and system specs for the new controller/policy/activity wiring) - full suite green, 0 failures
- [x] New system spec coverage: persists a `SessionFeedback`, generates an Activity for the other participant, rejects a duplicate submission cleanly, rejects a non-participant, allows submitting without picking a reaction
- [ ] Manual QA - see `docs/qa-plans/session-retro-submission-qa-plan.md` (not yet run; no in-app entry point exists yet for this slice, reachable via `/session_feedbacks/new?session_id=<id>` until the retro-nag job in a later issue links to it)

Generated with Claude Code

https://claude.ai/code/session_01L1tuhwo45XgjBBrfbwqTcM
