### PR TITLE
Instant join (no-approval path)

### DIFF
--- a/app/controllers/pair_requests/joins_controller.rb
+++ b/app/controllers/pair_requests/joins_controller.rb
@@ -1,0 +1,16 @@
+class PairRequests::JoinsController < ApplicationController
+  include Authenticated
+
+  def create
+    pair_request = PairRequest.find(params[:pair_request_id])
+
+    authorize pair_request, policy_class: PairRequests::JoinPolicy
+
+    PairRequests::InstantJoin
+      .call(pair_request.id, current_user)
+      .either(
+        -> (success) { redirect_to sessions_path, notice: "You're in! Happy pairin!" },
+        -> (failure) { redirect_to pair_requests_path, alert: "This request is no longer available to join." }
+      )
+  end
+end

--- a/app/javascript/pages/PairRequests/Card.jsx
+++ b/app/javascript/pages/PairRequests/Card.jsx
@@ -1,4 +1,4 @@
-import { Link } from "@inertiajs/react";
+import { Link, Form } from "@inertiajs/react";
 import { ArrowRight } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import ExpandableText from "@/components/ExpandableText";
@@ -71,7 +71,17 @@ export default function PairRequestCard({ pairRequest, currentUserId, live = fal
           </div>
         </div>
 
-        {!live && (
+        {live && !pairRequest.requires_approval && (
+          <Form method="post" action={`/pair_requests/${pairRequest.id}/join`}>
+            {({ processing }) => (
+              <Button type="submit" disabled={processing}>
+                {processing ? "..." : "Join"}
+              </Button>
+            )}
+          </Form>
+        )}
+
+        {(!live || pairRequest.requires_approval) && (
           alreadyOffered ? (
             <span className="text-sm font-bold italic text-black/40">You have already sent an offer</span>
           ) : (

--- a/app/policies/pair_requests/join_policy.rb
+++ b/app/policies/pair_requests/join_policy.rb
@@ -1,0 +1,7 @@
+module PairRequests
+  class JoinPolicy < ApplicationPolicy
+    def create?
+      record.user != user && record.mode == "immediate" && !record.requires_approval?
+    end
+  end
+end

--- a/app/resources/pair_request_browse_resource.rb
+++ b/app/resources/pair_request_browse_resource.rb
@@ -1,5 +1,5 @@
 class PairRequestBrowseResource < ApplicationResource
-  attributes :id, :subject, :description, :goal, :platform
+  attributes :id, :subject, :description, :goal, :platform, :requires_approval
 
   many :tags, resource: TagResource
 

--- a/app/services/pair_requests/instant_join.rb
+++ b/app/services/pair_requests/instant_join.rb
@@ -1,0 +1,45 @@
+require "dry/operation/extensions/active_record"
+
+module PairRequests
+  class InstantJoin < Dry::Operation
+    include Dry::Operation::Extensions::ActiveRecord
+
+    def self.call(...) = new.call(...)
+
+    def call(pair_request_id, joiner)
+      transaction do
+        pair_request = step lock_pair_request(pair_request_id)
+        step validate(pair_request, joiner)
+        offer = step build_offer(pair_request, joiner)
+        step Offers::Accept.call(offer)
+      end
+    end
+
+    private
+
+    def lock_pair_request(pair_request_id)
+      Success(PairRequest.lock.find(pair_request_id))
+    end
+
+    def validate(pair_request, joiner)
+      if pair_request.user == joiner ||
+         pair_request.mode != "immediate" ||
+         pair_request.requires_approval? ||
+         pair_request.has_accepted_offer?
+        Failure(:not_joinable)
+      else
+        Success()
+      end
+    end
+
+    def build_offer(pair_request, joiner)
+      offer = pair_request.offers.build(
+        offerer: joiner,
+        message: "Joined instantly",
+        period: pair_request.periods.first
+      )
+
+      offer.save ? Success(offer) : Failure(offer: offer, error: offer.errors)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resources :offers, only: [:index, :new, :create] do
         post "accept", on: :member
       end
+      resource :join, only: [:create], controller: "joins"
     end
 
     get :search, on: :collection

--- a/spec/requests/pair_requests/joins_spec.rb
+++ b/spec/requests/pair_requests/joins_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe "PairRequests::Joins", type: :request do
+  describe "POST /pair_requests/:pair_request_id/join" do
+    let(:current_user) { create(:user) }
+    let(:pair_request) { create(:pair_request, :immediate) }
+
+    before { sign_in(current_user) }
+
+    it "creates a session and redirects to sessions" do
+      expect {
+        post pair_request_join_path(pair_request)
+      }.to change { Session.count }.by(1)
+
+      expect(response).to redirect_to(sessions_path)
+      expect(flash[:notice]).to be_present
+    end
+
+    context "when the pair request requires approval" do
+      let(:pair_request) { create(:pair_request, :immediate, requires_approval: true) }
+
+      it "does not authorize the join and redirects with an alert" do
+        expect {
+          post pair_request_join_path(pair_request)
+        }.not_to change { Session.count }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the pair request is scheduled (not immediate)" do
+      let(:pair_request) { create(:pair_request) }
+
+      it "does not authorize the join and redirects with an alert" do
+        expect {
+          post pair_request_join_path(pair_request)
+        }.not_to change { Session.count }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the current user owns the pair request" do
+      let(:pair_request) { create(:pair_request, :immediate, user: current_user) }
+
+      it "does not authorize the join and redirects with an alert" do
+        expect {
+          post pair_request_join_path(pair_request)
+        }.not_to change { Session.count }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the pair request is already matched" do
+      before { create(:offer, :accepted, pair_request:) }
+
+      it "redirects back to pair requests with an alert" do
+        expect {
+          post pair_request_join_path(pair_request)
+        }.not_to change { Session.count }
+
+        expect(response).to redirect_to(pair_requests_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/pair_requests/instant_join_spec.rb
+++ b/spec/services/pair_requests/instant_join_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe PairRequests::InstantJoin, type: :unit do
+  describe ".call" do
+    subject(:call) { described_class.call(pair_request.id, joiner) }
+
+    let(:pair_request) { create(:pair_request, :immediate) }
+    let(:joiner) { create(:user) }
+
+    it "returns success" do
+      expect(call.success?).to be true
+    end
+
+    it "creates an accepted offer for the joiner using the immediate period" do
+      expect { call }.to change { pair_request.offers.count }.by(1)
+
+      offer = pair_request.reload.offers.last
+
+      expect(offer.offerer).to eq joiner
+      expect(offer.period).to eq pair_request.periods.first
+      expect(offer).to be_accepted
+    end
+
+    it "creates a session with both participants" do
+      expect { call }.to change { Session.count }.by(1)
+
+      session = Session.last
+
+      expect(session.sessionable).to eq pair_request
+      expect(session.participants).to contain_exactly(pair_request.user, joiner)
+    end
+
+    context "when the joiner is the pair request's own user" do
+      let(:joiner) { pair_request.user }
+
+      it "returns failure" do
+        expect(call.success?).to be false
+      end
+
+      it "doesn't create an offer or a session" do
+        expect { call }
+          .to not_change { Offer.count }
+          .and not_change { Session.count }
+      end
+    end
+
+    context "when the pair request is not in immediate mode" do
+      let(:pair_request) { create(:pair_request) }
+
+      it "returns failure" do
+        expect(call.success?).to be false
+      end
+    end
+
+    context "when the pair request already has an accepted offer" do
+      before { create(:offer, :accepted, pair_request:) }
+
+      it "returns failure" do
+        expect(call.success?).to be false
+      end
+
+      it "doesn't create a new session" do
+        expect { call }.not_to change { Session.count }
+      end
+    end
+
+    context "when the pair request requires approval" do
+      let(:pair_request) { create(:pair_request, :immediate, requires_approval: true) }
+
+      it "returns failure" do
+        expect(call.success?).to be false
+      end
+
+      it "doesn't create an offer or a session" do
+        expect { call }
+          .to not_change { Offer.count }
+          .and not_change { Session.count }
+      end
+    end
+
+    context "when two joiners attempt to instant-join the same pair request at once" do
+      self.use_transactional_tests = false
+
+      after do
+        Session.delete_all
+        Participation.delete_all
+        Offer.delete_all
+        Period.delete_all
+        PairRequest.delete_all
+        User.delete_all
+      end
+
+      it "only lets one succeed and creates a single session" do
+        pair_request = create(:pair_request, :immediate)
+        joiner_a = create(:user)
+        joiner_b = create(:user)
+        results = Queue.new
+
+        threads = [joiner_a, joiner_b].map do |joiner|
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              results << PairRequests::InstantJoin.call(pair_request.id, joiner)
+            end
+          end
+        end
+        threads.each(&:join)
+
+        outcomes = Array.new(2) { results.pop }
+
+        expect(outcomes.count(&:success?)).to eq 1
+        expect(outcomes.count(&:failure?)).to eq 1
+        expect(Session.where(sessionable: pair_request).count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,3 +1,4 @@
 RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/system/pair_requests/join_spec.rb
+++ b/spec/system/pair_requests/join_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "instant join a live pair request", type: :system do
+  let(:current_user) { create(:user) }
+
+  before { sign_in(current_user) }
+
+  context "when the live pair request doesn't require approval" do
+    let!(:live_pair_request) do
+      pair_request = create(:pair_request, :immediate, subject: "GGG", with_periods: false)
+      create(:period, periodable: pair_request, start_at: Time.current)
+      pair_request
+    end
+
+    it "joins the session immediately" do
+      visit pair_requests_path
+
+      click_button "Join"
+
+      expect(page).to have_content("You're in! Happy pairin!")
+    end
+  end
+
+  context "when the live pair request requires approval" do
+    let!(:live_pair_request) do
+      pair_request = create(:pair_request, :immediate, :requires_approval, subject: "GGG", with_periods: false)
+      create(:period, periodable: pair_request, start_at: Time.current)
+      pair_request
+    end
+
+    it "shows the Apply flow instead of a Join button" do
+      visit pair_requests_path
+
+      expect(page).to have_content("Apply")
+      expect(page).not_to have_button("Join")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds PairRequests::InstantJoin, mirroring the step/Success/Failure shape of Offers::Accept: locks the PairRequest row, validates ownership, mode, approval flag, and matched state, builds an Offer for the joiner, then delegates to Offers::Accept so session creation and notification stay in one place.
- New PairRequests::JoinsController and JoinPolicy gate the join route to non-owners on immediate, no-approval requests.
- Card.jsx now renders a Join button for those live requests instead of the Apply flow, using the new requires_approval attribute on PairRequestBrowseResource.

Closes #91

## Test plan
- [x] Service spec covers success, self-join, non-immediate mode, requires-approval, already-matched, and a real two-thread race test proving only one joiner succeeds and exactly one Session is created
- [x] Request specs cover happy path, requires-approval, non-immediate mode, self-owned request, and already-matched request
- [x] System spec covers the Join button flow and the Apply fallback when approval is required
- [x] Full suite green: 124 examples, 0 failures

Generated with Claude Code

https://claude.ai/code/session_01L1tuhwo45XgjBBrfbwqTcM