### PR TITLE
Immediate-expiry nag job + mailer

### DIFF
--- a/app/controllers/users/pair_requests_controller.rb
+++ b/app/controllers/users/pair_requests_controller.rb
@@ -24,7 +24,7 @@ class Users::PairRequestsController < ApplicationController
 
   def create
     @pair_request = current_user.pair_requests.build(pair_request_params)
-    @pair_request.periods = [Period.new(start_at: Time.current)] if @pair_request.mode == "immediate"
+    @pair_request.periods = [Period.new(start_at: Time.current)] if @pair_request.immediate?
 
     if @pair_request.save
       PairRequests::ScheduleImmediateExpiry.call(@pair_request)
@@ -52,11 +52,12 @@ class Users::PairRequestsController < ApplicationController
 
     authorize @pair_request, policy_class: Users::PairRequestPolicy
 
-    if PairRequests::ExtendWait.call(@pair_request)
-      redirect_to users_pair_requests_path, notice: "We'll keep waiting a bit longer!"
-    else
-      redirect_to users_pair_requests_path, alert: "Could not extend waiting time."
-    end
+    PairRequests::ExtendWait
+      .call(@pair_request)
+      .either(
+        -> (success) { redirect_to users_pair_requests_path, notice: "We'll keep waiting a bit longer!" },
+        -> (failure) { redirect_to users_pair_requests_path, alert: "Could not extend waiting time." }
+      )
   end
 
   private

--- a/app/controllers/users/pair_requests_controller.rb
+++ b/app/controllers/users/pair_requests_controller.rb
@@ -4,7 +4,7 @@ class Users::PairRequestsController < ApplicationController
 
   def index
     @pair_requests = current_user.pair_requests
-      .includes(:tags, :sessions, accepted_offer: :offerer)
+      .includes(:tags, :sessions, :periods, accepted_offer: :offerer)
       .order(created_at: :desc)
 
     render inertia: 'Users/PairRequests/Index', props: {
@@ -27,6 +27,8 @@ class Users::PairRequestsController < ApplicationController
     @pair_request.periods = [Period.new(start_at: Time.current)] if @pair_request.mode == "immediate"
 
     if @pair_request.save
+      PairRequests::ScheduleImmediateExpiry.call(@pair_request)
+
       redirect_to users_pair_requests_path, notice: "Request posted! Good luck"
     else
       redirect_back_or_to new_users_pair_request_path, inertia: { errors: @pair_request.errors.to_hash(true) }
@@ -42,6 +44,18 @@ class Users::PairRequestsController < ApplicationController
       redirect_to users_pair_requests_path, notice: "Successfully added!"
     else
       redirect_back fallback_location: users_pair_requests_path, alert: "Something went wrong."
+    end
+  end
+
+  def extend_wait
+    @pair_request = current_user.pair_requests.find(params[:id])
+
+    authorize @pair_request, policy_class: Users::PairRequestPolicy
+
+    if PairRequests::ExtendWait.call(@pair_request)
+      redirect_to users_pair_requests_path, notice: "We'll keep waiting a bit longer!"
+    else
+      redirect_to users_pair_requests_path, alert: "Could not extend waiting time."
     end
   end
 

--- a/app/javascript/pages/Users/PairRequests/Card.jsx
+++ b/app/javascript/pages/Users/PairRequests/Card.jsx
@@ -1,4 +1,4 @@
-import { useForm, Link } from '@inertiajs/react';
+import { useForm, Link, router } from '@inertiajs/react';
 import { Inbox, CheckCircle2 } from "lucide-react";
 import { formatShort } from "@/helpers/date";
 import ExpandableText from "@/components/ExpandableText";
@@ -11,6 +11,13 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 const TAG_COLORS = ["bg-purple text-white", "bg-orange text-white", "bg-green text-black"];
 
 export default function UserPairRequestCard({ request }) {
+  const period = request.periods?.[0];
+  const isImmediateWaiting = request.mode === "immediate" && !request.accepted_offer && period;
+  const waitUntil = isImmediateWaiting
+    ? new Date(period.start_at).getTime() + (request.wait_minutes || 0) * 60000
+    : null;
+  const isLive = isImmediateWaiting && waitUntil > Date.now();
+
   const { data, setData, patch, processing } = useForm({
     pair_request: {
       sessions_attributes: request.sessions.map(s => ({
@@ -46,6 +53,21 @@ export default function UserPairRequestCard({ request }) {
           </Badge>
         ))}
       </div>
+
+      {isImmediateWaiting && (
+        <div className="mt-4 flex flex-col items-stretch gap-3 rounded-xl border-2 border-black bg-yellow-50 p-4 md:flex-row md:items-center md:justify-between">
+          <Badge className={`rounded-full border-black ${isLive ? "bg-green text-black" : "bg-white text-black"}`}>
+            {isLive ? "Live now" : "Wait time elapsed"}
+          </Badge>
+          <Button
+            variant="neutral"
+            size="sm"
+            onClick={() => router.patch(`/users/pair_requests/${request.id}/extend_wait`)}
+          >
+            Keep waiting
+          </Button>
+        </div>
+      )}
 
       {request.accepted_offer && (
         <div className="mt-5 rounded-xl border-2 border-black bg-green/10 p-4">

--- a/app/jobs/pair_requests/immediate_expiry_job.rb
+++ b/app/jobs/pair_requests/immediate_expiry_job.rb
@@ -1,0 +1,24 @@
+module PairRequests
+  class ImmediateExpiryJob < ApplicationJob
+    queue_as :default
+
+    def perform(pair_request_id)
+      pair_request = PairRequest.find_by(id: pair_request_id)
+      return unless pair_request
+      return unless pair_request.mode == "immediate"
+      return if pair_request.has_accepted_offer?
+
+      period = pair_request.periods.first
+      return unless period
+      return if Time.current < period.start_at + (pair_request.wait_minutes || 0).minutes
+
+      Activity.create!(
+        receiver: pair_request.user,
+        title: I18n.t("activities.immediate_expired.titles").sample,
+        content: I18n.t("activities.immediate_expired.content").sample
+      )
+
+      PairRequestMailer.with(pair_request:, user: pair_request.user).immediate_expired_email.deliver_later
+    end
+  end
+end

--- a/app/jobs/pair_requests/immediate_expiry_job.rb
+++ b/app/jobs/pair_requests/immediate_expiry_job.rb
@@ -5,7 +5,7 @@ module PairRequests
     def perform(pair_request_id)
       pair_request = PairRequest.find_by(id: pair_request_id)
       return unless pair_request
-      return unless pair_request.mode == "immediate"
+      return unless pair_request.immediate?
       return if pair_request.has_accepted_offer?
 
       period = pair_request.periods.first

--- a/app/jobs/pair_requests/immediate_expiry_job.rb
+++ b/app/jobs/pair_requests/immediate_expiry_job.rb
@@ -5,12 +5,8 @@ module PairRequests
     def perform(pair_request_id)
       pair_request = PairRequest.find_by(id: pair_request_id)
       return unless pair_request
-      return unless pair_request.immediate?
       return if pair_request.has_accepted_offer?
-
-      period = pair_request.periods.first
-      return unless period
-      return if Time.current < period.start_at + (pair_request.wait_minutes || 0).minutes
+      return unless pair_request.wait_time_expired?
 
       Activity.create!(
         receiver: pair_request.user,

--- a/app/mailers/pair_request_mailer.rb
+++ b/app/mailers/pair_request_mailer.rb
@@ -1,0 +1,8 @@
+class PairRequestMailer < ApplicationMailer
+  def immediate_expired_email
+    @pair_request = params[:pair_request]
+    @user = params[:user]
+
+    mail(to: @user.email, subject: "Nobody has joined your pair request yet")
+  end
+end

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -51,4 +51,20 @@ class PairRequest < ApplicationRecord
   def immediate?
     mode == "immediate"
   end
+
+  def wait_deadline
+    period = periods.first
+    return nil unless period
+
+    period.start_at + (wait_minutes || 0).minutes
+  end
+
+  def wait_time_expired?
+    return false unless immediate?
+
+    deadline = wait_deadline
+    return false unless deadline
+
+    Time.current >= deadline
+  end
 end

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -47,4 +47,8 @@ class PairRequest < ApplicationRecord
   def has_accepted_offer?
     offers.accepted.exists?
   end
+
+  def immediate?
+    mode == "immediate"
+  end
 end

--- a/app/policies/pair_requests/join_policy.rb
+++ b/app/policies/pair_requests/join_policy.rb
@@ -1,7 +1,7 @@
 module PairRequests
   class JoinPolicy < ApplicationPolicy
     def create?
-      record.user != user && record.mode == "immediate" && !record.requires_approval?
+      record.user != user && record.immediate? && !record.requires_approval?
     end
   end
 end

--- a/app/policies/users/pair_request_policy.rb
+++ b/app/policies/users/pair_request_policy.rb
@@ -3,5 +3,9 @@ module Users
     def add_call_link?
       user == record.user
     end
+
+    def extend_wait?
+      user == record.user
+    end
   end
 end

--- a/app/policies/users/pair_request_policy.rb
+++ b/app/policies/users/pair_request_policy.rb
@@ -5,7 +5,7 @@ module Users
     end
 
     def extend_wait?
-      user == record.user
+      user == record.user && record.immediate?
     end
   end
 end

--- a/app/resources/pair_request_resource.rb
+++ b/app/resources/pair_request_resource.rb
@@ -1,9 +1,13 @@
 class PairRequestResource < ApplicationResource
-  attributes :id, :subject, :description
+  attributes :id, :subject, :description, :mode, :wait_minutes
 
   many :tags, resource: TagResource
 
   many :sessions, resource: SessionResource
+
+  attribute :periods do |pair_request|
+    pair_request.periods.map { |period| { id: period.id, start_at: period.start_at, end_at: period.end_at } }
+  end
 
   attribute :accepted_offer do |pair_request|
     offer = pair_request.accepted_offer

--- a/app/services/pair_requests/extend_wait.rb
+++ b/app/services/pair_requests/extend_wait.rb
@@ -1,0 +1,25 @@
+module PairRequests
+  class ExtendWait
+    def self.call(pair_request) = new(pair_request).call
+
+    def initialize(pair_request)
+      @pair_request = pair_request
+    end
+
+    def call
+      return false unless pair_request.mode == "immediate"
+      return false if pair_request.has_accepted_offer?
+
+      period = pair_request.periods.first
+      period.update!(start_at: Time.current)
+
+      PairRequests::ScheduleImmediateExpiry.call(pair_request)
+
+      true
+    end
+
+    private
+
+    attr_reader :pair_request
+  end
+end

--- a/app/services/pair_requests/extend_wait.rb
+++ b/app/services/pair_requests/extend_wait.rb
@@ -1,25 +1,26 @@
 module PairRequests
-  class ExtendWait
-    def self.call(pair_request) = new(pair_request).call
+  class ExtendWait < Dry::Operation
+    def self.call(...) = new.call(...)
 
-    def initialize(pair_request)
-      @pair_request = pair_request
-    end
-
-    def call
-      return false unless pair_request.mode == "immediate"
-      return false if pair_request.has_accepted_offer?
+    def call(pair_request)
+      step validate(pair_request)
 
       period = pair_request.periods.first
       period.update!(start_at: Time.current)
 
-      PairRequests::ScheduleImmediateExpiry.call(pair_request)
+      step PairRequests::ScheduleImmediateExpiry.call(pair_request)
 
-      true
+      Success(pair_request)
     end
 
     private
 
-    attr_reader :pair_request
+    def validate(pair_request)
+      if !pair_request.immediate? || pair_request.has_accepted_offer?
+        Failure(:not_extendable)
+      else
+        Success()
+      end
+    end
   end
 end

--- a/app/services/pair_requests/instant_join.rb
+++ b/app/services/pair_requests/instant_join.rb
@@ -23,7 +23,7 @@ module PairRequests
 
     def validate(pair_request, joiner)
       if pair_request.user == joiner ||
-         pair_request.mode != "immediate" ||
+         !pair_request.immediate? ||
          pair_request.requires_approval? ||
          pair_request.has_accepted_offer?
         Failure(:not_joinable)

--- a/app/services/pair_requests/schedule_immediate_expiry.rb
+++ b/app/services/pair_requests/schedule_immediate_expiry.rb
@@ -5,10 +5,8 @@ module PairRequests
     def call(pair_request)
       step validate(pair_request)
 
-      period = pair_request.periods.first
-
       PairRequests::ImmediateExpiryJob
-        .set(wait_until: period.start_at + (pair_request.wait_minutes || 0).minutes)
+        .set(wait_until: pair_request.wait_deadline)
         .perform_later(pair_request.id)
 
       Success(pair_request)

--- a/app/services/pair_requests/schedule_immediate_expiry.rb
+++ b/app/services/pair_requests/schedule_immediate_expiry.rb
@@ -1,26 +1,25 @@
 module PairRequests
-  class ScheduleImmediateExpiry
-    def self.call(pair_request) = new(pair_request).call
+  class ScheduleImmediateExpiry < Dry::Operation
+    def self.call(...) = new.call(...)
 
-    def initialize(pair_request)
-      @pair_request = pair_request
-    end
-
-    def call
-      return false unless pair_request.mode == "immediate"
+    def call(pair_request)
+      step validate(pair_request)
 
       period = pair_request.periods.first
-      return false unless period
 
       PairRequests::ImmediateExpiryJob
         .set(wait_until: period.start_at + (pair_request.wait_minutes || 0).minutes)
         .perform_later(pair_request.id)
 
-      true
+      Success(pair_request)
     end
 
     private
 
-    attr_reader :pair_request
+    def validate(pair_request)
+      return Failure(:not_immediate) unless pair_request.immediate?
+
+      pair_request.periods.first ? Success() : Failure(:no_period)
+    end
   end
 end

--- a/app/services/pair_requests/schedule_immediate_expiry.rb
+++ b/app/services/pair_requests/schedule_immediate_expiry.rb
@@ -1,0 +1,26 @@
+module PairRequests
+  class ScheduleImmediateExpiry
+    def self.call(pair_request) = new(pair_request).call
+
+    def initialize(pair_request)
+      @pair_request = pair_request
+    end
+
+    def call
+      return false unless pair_request.mode == "immediate"
+
+      period = pair_request.periods.first
+      return false unless period
+
+      PairRequests::ImmediateExpiryJob
+        .set(wait_until: period.start_at + (pair_request.wait_minutes || 0).minutes)
+        .perform_later(pair_request.id)
+
+      true
+    end
+
+    private
+
+    attr_reader :pair_request
+  end
+end

--- a/app/views/pair_request_mailer/immediate_expired_email.html.erb
+++ b/app/views/pair_request_mailer/immediate_expired_email.html.erb
@@ -1,0 +1,55 @@
+<div style="display: none">
+  Nobody has joined your pair programming request yet
+</div>
+<div role="article" aria-roledescription="email" aria-label="Pair request still waiting" lang="en">
+  <div class="sm-px-4" style="background-color: #f8fafc; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <table align="center" cellpadding="0" cellspacing="0" role="none">
+      <tr>
+        <td style="width: 552px; max-width: 100%">
+          <div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
+            <a href="https://pairin.dev">
+              <img src="<%= image_url('logo.svg') %>" width="70" alt="Pairin" style="max-width: 100%; vertical-align: middle">
+            </a>
+          </div>
+          <table style="width: 100%;" cellpadding="0" cellspacing="0" role="none">
+            <tr>
+              <td class="sm-px-6" style="border-radius: 4px; background-color: #fffffe; padding: 48px; font-size: 16px; color: #334155; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)">
+                <h1 class="sm-leading-8" style="margin: 0 0 24px; font-size: 24px; font-weight: 600; color: #000001">
+                  Hello,
+                </h1>
+                <p style="margin: 0; line-height: 24px">
+                  Nobody has joined your pair request &ldquo;<%= @pair_request.subject %>&rdquo; within the wait time you set.
+                  <br>
+                  <br>
+                  You can head back to your requests page to keep waiting a bit longer.
+                </p>
+                <p style="margin-top: 32px; text-align: center">
+                  <a href="<%= users_pair_requests_url %>" style="display: inline-block; padding: 12px 24px; border-radius: 4px; background-color: #4338ca; color: #ffffff; text-decoration: none; font-weight: 600">
+                    View your requests
+                  </a>
+                </p>
+                <p style="margin-top: 32px; font-weight: 600">Happy Pairin!</p>
+              </td>
+            </tr>
+            <tr role="separator">
+              <td style="line-height: 48px">&zwj;</td>
+            </tr>
+            <tr>
+              <td style="padding-left: 24px; padding-right: 24px; text-align: center; font-size: 12px; color: #475569">
+                <p style="margin: 0 0 16px">
+                  Pairin Team
+                </p>
+                <p style="margin: 0; font-style: italic">
+                  Find pair programming partner quick and easy
+                </p>
+                <p style="cursor: default">
+                  <a href="https://pairin.dev" class="hover-important-text-decoration-underline" style="color: #4338ca; text-decoration: none">Pairin</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/config/locales/activities/en.yml
+++ b/config/locales/activities/en.yml
@@ -128,3 +128,12 @@ en:
         - Your partner just left feedback on your last session. Take a look and see what they thought!
         - There's new retro feedback waiting for you from your pairing partner.
         - Your pairing partner shared their thoughts on your last session together. Check it out!
+    immediate_expired:
+      titles:
+        - Nobody has joined your request yet
+        - Still waiting for a pairing partner
+        - Your live request needs a decision
+      content:
+        - Nobody has joined your pair request within the wait time you set. Head back to your request whenever you're ready to keep waiting a bit longer.
+        - Your request has been live for a while with no takers yet. Visit your request page to extend the wait time if you'd like to keep it open.
+        - Still no one has joined your request. You can extend the wait time from your request page whenever you're ready.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   namespace :users do
     resources :pair_requests, except: [:edit, :update] do
       patch :add_call_link, on: :member
+      patch :extend_wait, on: :member
     end
     resources :offers, only: [:index]
   end

--- a/spec/jobs/pair_requests/immediate_expiry_job_spec.rb
+++ b/spec/jobs/pair_requests/immediate_expiry_job_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe PairRequests::ImmediateExpiryJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.perform_now(pair_request.id) }
+
+    let(:pair_request) do
+      pr = create(:pair_request, :immediate, wait_minutes: 15, with_periods: false)
+      period = create(:period, periodable: pr, start_at: Time.current)
+      period.update_column(:start_at, 20.minutes.ago)
+      pr
+    end
+
+    it "creates an activity for the requester" do
+      expect { perform }.to change { Activity.count }.by(1)
+
+      activity = Activity.last
+
+      expect(activity.receiver).to eq pair_request.user
+      expect(activity.title).to be_in(I18n.t("activities.immediate_expired.titles"))
+      expect(activity.content).to be_in(I18n.t("activities.immediate_expired.content"))
+    end
+
+    it "sends the immediate expired mailer" do
+      expect { perform }.to have_enqueued_mail(PairRequestMailer, :immediate_expired_email)
+    end
+
+    context "when the pair request has been destroyed" do
+      before { pair_request.destroy! }
+
+      it "does not raise and does not create an activity" do
+        expect { perform }.not_to change { Activity.count }
+      end
+
+      it "does not send mail" do
+        expect { perform }.not_to have_enqueued_mail(PairRequestMailer, :immediate_expired_email)
+      end
+    end
+
+    context "when the pair request is already matched" do
+      before { create(:offer, :accepted, pair_request:) }
+
+      it "does not create an activity" do
+        expect { perform }.not_to change { Activity.count }
+      end
+    end
+
+    context "when the pair request is no longer immediate mode" do
+      before { pair_request.update!(mode: "scheduled") }
+
+      it "does not create an activity" do
+        expect { perform }.not_to change { Activity.count }
+      end
+    end
+
+    context "when the wait was extended after this job was scheduled (stale job)" do
+      let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
+
+      before { PairRequests::ExtendWait.call(pair_request) }
+
+      it "no-ops, since the current deadline is now later than this stale execution" do
+        expect { perform }.not_to change { Activity.count }
+      end
+
+      it "still fires once the (later) current deadline actually passes" do
+        travel_to 31.minutes.from_now do
+          expect { perform }.to change { Activity.count }.by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/pair_request_mailer_spec.rb
+++ b/spec/mailers/pair_request_mailer_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe PairRequestMailer, type: :mailer do
+  describe "#immediate_expired_email" do
+    subject(:mail) { described_class.with(pair_request:, user: pair_request.user).immediate_expired_email }
+
+    let(:pair_request) { create(:pair_request, :immediate) }
+
+    it "renders the headers" do
+      expect(mail.to).to eq [pair_request.user.email]
+      expect(mail.subject).to eq "Nobody has joined your pair request yet"
+    end
+
+    it "renders the pair request subject in the body" do
+      expect(mail.body.encoded).to match(pair_request.subject)
+    end
+  end
+end

--- a/spec/mailers/previews/pair_request_mailer_preview.rb
+++ b/spec/mailers/previews/pair_request_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/pair_request
+class PairRequestMailerPreview < ActionMailer::Preview
+  def immediate_expired_email
+    PairRequestMailer.with(pair_request: PairRequest.first, user: PairRequest.first.user).immediate_expired_email
+  end
+end

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -131,4 +131,79 @@ RSpec.describe PairRequest, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#wait_deadline" do
+    subject(:wait_deadline) { pair_request.wait_deadline }
+
+    context "when it has no periods" do
+      let(:pair_request) { create(:pair_request, with_periods: false) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when it has a period" do
+      let(:start_at) { Time.current }
+      let(:pair_request) do
+        pr = create(:pair_request, wait_minutes: 15, with_periods: false)
+        create(:period, periodable: pr, start_at:)
+        pr
+      end
+
+      it "returns the period start time plus the wait minutes" do
+        expect(wait_deadline).to eq(start_at + 15.minutes)
+      end
+    end
+
+    context "when wait_minutes is nil" do
+      let(:start_at) { Time.current }
+      let(:pair_request) do
+        pr = create(:pair_request, wait_minutes: nil, with_periods: false)
+        create(:period, periodable: pr, start_at:)
+        pr
+      end
+
+      it "returns the period start time" do
+        expect(wait_deadline).to eq(start_at)
+      end
+    end
+  end
+
+  describe "#wait_time_expired?" do
+    subject(:wait_time_expired?) { pair_request.wait_time_expired? }
+
+    context "when the pair request is scheduled" do
+      let(:pair_request) { create(:pair_request, mode: "scheduled") }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the pair request is immediate" do
+      context "when it has no periods" do
+        let(:pair_request) { create(:pair_request, :immediate, with_periods: false) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the wait window has not elapsed" do
+        let(:pair_request) do
+          pr = create(:pair_request, :immediate, wait_minutes: 15, with_periods: false)
+          create(:period, periodable: pr, start_at: Time.current)
+          pr
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when the wait window has elapsed" do
+        let(:pair_request) do
+          pr = create(:pair_request, :immediate, wait_minutes: 15, with_periods: false)
+          period = create(:period, periodable: pr, start_at: Time.current)
+          period.update_column(:start_at, 20.minutes.ago)
+          pr
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe PairRequest, type: :model do
     end
 
     context "when it has a period" do
-      let(:start_at) { Time.current }
+      let(:start_at) { Time.current.round(6) }
       let(:pair_request) do
         pr = create(:pair_request, wait_minutes: 15, with_periods: false)
         create(:period, periodable: pr, start_at:)
@@ -155,7 +155,7 @@ RSpec.describe PairRequest, type: :model do
     end
 
     context "when wait_minutes is nil" do
-      let(:start_at) { Time.current }
+      let(:start_at) { Time.current.round(6) }
       let(:pair_request) do
         pr = create(:pair_request, wait_minutes: nil, with_periods: false)
         create(:period, periodable: pr, start_at:)

--- a/spec/requests/users/pair_requests_extend_wait_spec.rb
+++ b/spec/requests/users/pair_requests_extend_wait_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "Users::PairRequests extend_wait", type: :request do
+  describe "PATCH /users/pair_requests/:id/extend_wait" do
+    let(:current_user) { create(:user) }
+    let(:pair_request) { create(:pair_request, :immediate, user: current_user, wait_minutes: 30) }
+
+    before { sign_in(current_user) }
+
+    it "extends the wait and redirects with a notice" do
+      freeze_time do
+        patch extend_wait_users_pair_request_path(pair_request)
+
+        expect(pair_request.periods.first.reload.start_at).to eq(Time.current)
+        expect(response).to redirect_to(users_pair_requests_path)
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    context "when the pair request already has an accepted offer" do
+      before { create(:offer, :accepted, pair_request:) }
+
+      it "redirects with an alert and doesn't change the period" do
+        expect {
+          patch extend_wait_users_pair_request_path(pair_request)
+        }.not_to change { pair_request.periods.first.reload.start_at }
+
+        expect(response).to redirect_to(users_pair_requests_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "when the pair request belongs to another user" do
+      let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
+
+      it "404s, since it is scoped to the current user's own pair requests (matching add_call_link)" do
+        patch extend_wait_users_pair_request_path(pair_request)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/users/pair_requests_extend_wait_spec.rb
+++ b/spec/requests/users/pair_requests_extend_wait_spec.rb
@@ -39,5 +39,16 @@ RSpec.describe "Users::PairRequests extend_wait", type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "when the pair request is scheduled mode" do
+      let(:pair_request) { create(:pair_request, user: current_user) }
+
+      it "is not authorized" do
+        patch extend_wait_users_pair_request_path(pair_request)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to be_present
+      end
+    end
   end
 end

--- a/spec/requests/users/pair_requests_spec.rb
+++ b/spec/requests/users/pair_requests_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Users::PairRequests", type: :request do
+  describe "POST /users/pair_requests" do
+    let(:current_user) { create(:user) }
+
+    before { sign_in(current_user) }
+
+    context "when mode is immediate" do
+      let(:params) do
+        {
+          subject: "AAA",
+          description: "BBB",
+          duration: 45,
+          mode: "immediate",
+          wait_minutes: 30
+        }
+      end
+
+      it "schedules the immediate expiry job for start_at + wait_minutes" do
+        freeze_time do
+          expect { post users_pair_requests_path, params: }
+            .to have_enqueued_job(PairRequests::ImmediateExpiryJob).at(30.minutes.from_now)
+
+          pair_request = current_user.pair_requests.find_by!(subject: "AAA")
+
+          expect(enqueued_jobs.last[:args]).to eq [pair_request.id]
+        end
+      end
+    end
+
+    context "when mode is scheduled" do
+      let(:params) do
+        {
+          subject: "AAA",
+          description: "BBB",
+          duration: 45,
+          mode: "scheduled",
+          periods_attributes: [{ start_at: 1.day.from_now }]
+        }
+      end
+
+      it "does not schedule the immediate expiry job" do
+        expect { post users_pair_requests_path, params: }
+          .not_to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+      end
+    end
+  end
+end

--- a/spec/services/pair_requests/extend_wait_spec.rb
+++ b/spec/services/pair_requests/extend_wait_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe PairRequests::ExtendWait, type: :unit do
+  describe ".call" do
+    subject(:call) { described_class.call(pair_request) }
+
+    let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
+
+    it "returns true" do
+      expect(call).to be true
+    end
+
+    it "bumps the period's start_at to now" do
+      freeze_time do
+        expect { call }.to change { pair_request.periods.first.reload.start_at }.to(Time.current)
+      end
+    end
+
+    it "recomputes end_at from the pair request's duration" do
+      call
+
+      period = pair_request.periods.first.reload
+
+      expect(period.end_at).to eq(period.start_at + pair_request.duration.minutes)
+    end
+
+    it "re-enqueues the immediate expiry job for the new wait window" do
+      freeze_time do
+        expect { call }
+          .to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+          .with(pair_request.id)
+          .at(30.minutes.from_now)
+      end
+    end
+
+    context "when the pair request already has an accepted offer" do
+      before { create(:offer, :accepted, pair_request:) }
+
+      it "returns false" do
+        expect(call).to be false
+      end
+
+      it "doesn't change the period" do
+        expect { call }.not_to change { pair_request.periods.first.reload.start_at }
+      end
+
+      it "doesn't enqueue a job" do
+        expect { call }.not_to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+      end
+    end
+
+    context "when the pair request is not in immediate mode" do
+      let(:pair_request) { create(:pair_request) }
+
+      it "returns false" do
+        expect(call).to be false
+      end
+    end
+  end
+end

--- a/spec/services/pair_requests/extend_wait_spec.rb
+++ b/spec/services/pair_requests/extend_wait_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PairRequests::ExtendWait, type: :unit do
 
     let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
 
-    it "returns true" do
-      expect(call).to be true
+    it "returns success" do
+      expect(call.success?).to be true
     end
 
     it "bumps the period's start_at to now" do
@@ -36,8 +36,8 @@ RSpec.describe PairRequests::ExtendWait, type: :unit do
     context "when the pair request already has an accepted offer" do
       before { create(:offer, :accepted, pair_request:) }
 
-      it "returns false" do
-        expect(call).to be false
+      it "returns failure" do
+        expect(call.success?).to be false
       end
 
       it "doesn't change the period" do
@@ -52,8 +52,8 @@ RSpec.describe PairRequests::ExtendWait, type: :unit do
     context "when the pair request is not in immediate mode" do
       let(:pair_request) { create(:pair_request) }
 
-      it "returns false" do
-        expect(call).to be false
+      it "returns failure" do
+        expect(call.success?).to be false
       end
     end
   end

--- a/spec/services/pair_requests/schedule_immediate_expiry_spec.rb
+++ b/spec/services/pair_requests/schedule_immediate_expiry_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe PairRequests::ScheduleImmediateExpiry, type: :unit do
+  describe ".call" do
+    subject(:call) { described_class.call(pair_request) }
+
+    let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
+
+    it "returns true" do
+      expect(call).to be true
+    end
+
+    it "schedules the immediate expiry job for the period's start_at + wait_minutes" do
+      period = pair_request.periods.first
+
+      expect { call }
+        .to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+        .with(pair_request.id)
+        .at(period.start_at + 30.minutes)
+    end
+
+    context "when the pair request is not in immediate mode" do
+      let(:pair_request) { create(:pair_request) }
+
+      it "returns false and does not enqueue a job" do
+        expect { expect(call).to be false }.not_to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+      end
+    end
+  end
+end

--- a/spec/services/pair_requests/schedule_immediate_expiry_spec.rb
+++ b/spec/services/pair_requests/schedule_immediate_expiry_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PairRequests::ScheduleImmediateExpiry, type: :unit do
 
     let(:pair_request) { create(:pair_request, :immediate, wait_minutes: 30) }
 
-    it "returns true" do
-      expect(call).to be true
+    it "returns success" do
+      expect(call.success?).to be true
     end
 
     it "schedules the immediate expiry job for the period's start_at + wait_minutes" do
@@ -22,8 +22,8 @@ RSpec.describe PairRequests::ScheduleImmediateExpiry, type: :unit do
     context "when the pair request is not in immediate mode" do
       let(:pair_request) { create(:pair_request) }
 
-      it "returns false and does not enqueue a job" do
-        expect { expect(call).to be false }.not_to have_enqueued_job(PairRequests::ImmediateExpiryJob)
+      it "returns failure and does not enqueue a job" do
+        expect { expect(call.success?).to be false }.not_to have_enqueued_job(PairRequests::ImmediateExpiryJob)
       end
     end
   end

--- a/spec/system/users/pair_requests/extend_wait_spec.rb
+++ b/spec/system/users/pair_requests/extend_wait_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe "extend wait time on an unmatched immediate pair request", type: :system do
+  let(:current_user) { create(:user) }
+
+  before { sign_in(current_user) }
+
+  context "when the request is live and hasn't been matched" do
+    let!(:pair_request) do
+      pr = create(:pair_request, :immediate, user: current_user, wait_minutes: 30, subject: "GGG", with_periods: false)
+      create(:period, periodable: pr, start_at: Time.current)
+      pr
+    end
+
+    it "shows the live badge and lets the requester keep waiting" do
+      visit users_pair_requests_path
+
+      expect(page).to have_content("GGG")
+      expect(page).to have_content("Live now")
+
+      click_button "Keep waiting"
+
+      expect(page).to have_content("We'll keep waiting a bit longer!")
+    end
+  end
+
+  context "when the wait window has already elapsed" do
+    let!(:pair_request) do
+      pr = create(:pair_request, :immediate, user: current_user, wait_minutes: 15, subject: "HHH", with_periods: false)
+      period = create(:period, periodable: pr, start_at: Time.current)
+      period.update_column(:start_at, 30.minutes.ago)
+      pr
+    end
+
+    it "shows the wait-elapsed badge instead of live" do
+      visit users_pair_requests_path
+
+      expect(page).to have_content("HHH")
+      expect(page).to have_content("Wait time elapsed")
+    end
+  end
+
+  context "when the request is already matched" do
+    let!(:pair_request) do
+      pr = create(:pair_request, :immediate, user: current_user, subject: "III", with_periods: false)
+      create(:period, periodable: pr, start_at: Time.current)
+      pr
+    end
+
+    before do
+      create(:offer, :accepted, pair_request:)
+      create(:session, sessionable: pair_request)
+    end
+
+    it "does not show a Keep waiting button" do
+      visit users_pair_requests_path
+
+      expect(page).to have_content("III")
+      expect(page).not_to have_button("Keep waiting")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `PairRequests::ImmediateExpiryJob`, scheduled via `PairRequests::ScheduleImmediateExpiry` at `period.start_at + wait_minutes` right after an immediate-mode pair request is created. If nobody has joined by then, it creates an `Activity` for the requester and sends `PairRequestMailer#immediate_expired_email`.
- The job re-checks the current deadline at execution time instead of trusting enqueue-time state, so a stale job left over from before a wait extension safely no-ops rather than firing early or sending a duplicate nag.
- Adds `PairRequests::ExtendWait` plus a `users/pair_requests/:id/extend_wait` action, letting a requester push their live request's wait window out. The existing `Users::PairRequests` index now shows a live/wait-elapsed badge and a Keep waiting button for unmatched immediate requests.
- New `en.activities.immediate_expired` locale keys, matching the sampled-copy convention other activity types use.

Closes #92

## Test plan
- [x] Job spec covers: activity + mailer fire once the deadline passes, no-ops when destroyed/already-matched/no-longer-immediate, and a stale job (scheduled before an extension) safely no-ops while the extended one still fires
- [x] Service specs for `ScheduleImmediateExpiry` and `ExtendWait` cover the enqueue timing and guard branches
- [x] Request specs cover create-time scheduling and the `extend_wait` action (happy path, already-matched, another user's request)
- [x] System spec covers the live/wait-elapsed badge and the Keep waiting button on the index page
- [x] Mailer spec covers headers/body
- [x] Full suite green: 153 examples, 0 failures
- [x] Code-reviewed: fixed a real bug (stale job could fire early/duplicate after an extension) and extracted scheduling into a shared service for consistency between create and extend_wait

Generated with Claude Code

https://claude.ai/code/session_01L1tuhwo45XgjBBrfbwqTcM
