### PR TITLE
Retro nag job + mailer (#94)

### DIFF
--- a/app/jobs/session_feedback_nag_job.rb
+++ b/app/jobs/session_feedback_nag_job.rb
@@ -1,0 +1,20 @@
+class SessionFeedbackNagJob < ApplicationJob
+  queue_as :default
+
+  def perform(session_id)
+    session = Session.find_by(id: session_id)
+    return unless session
+
+    session.participants.each do |participant|
+      next if session.feedback_from(participant).present?
+
+      Activity.create!(
+        receiver: participant,
+        title: I18n.t("activities.retro_nag.titles").sample,
+        content: I18n.t("activities.retro_nag.content").sample
+      )
+
+      SessionMailer.with(session:, participant:).retro_nag_email.deliver_later
+    end
+  end
+end

--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -5,4 +5,11 @@ class SessionMailer < ApplicationMailer
 
     mail(to: @participant.email, subject: "Your pair programming session has been scheduled")
   end
+
+  def retro_nag_email
+    @session = params[:session]
+    @participant = params[:participant]
+
+    mail(to: @participant.email, subject: "Don't forget to leave feedback for your last session")
+  end
 end

--- a/app/services/offers/accept.rb
+++ b/app/services/offers/accept.rb
@@ -43,6 +43,8 @@ module Offers
         end_at: offer.period.end_at
       )
 
+      SessionFeedbackNagJob.set(wait_until: session.end_at + 5.minutes).perform_later(session.id)
+
       session.participations.create!(participant: offer.offerer, role: Participation::ROLE_PAIR)
       session.participations.create!(participant: pair_request.user, role: Participation::ROLE_INITIATOR)
 

--- a/app/views/session_mailer/retro_nag_email.html.erb
+++ b/app/views/session_mailer/retro_nag_email.html.erb
@@ -1,0 +1,55 @@
+<div style="display: none">
+  Don't forget to leave feedback for your last pair programming session
+</div>
+<div role="article" aria-roledescription="email" aria-label="Retro feedback reminder" lang="en">
+  <div class="sm-px-4" style="background-color: #f8fafc; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <table align="center" cellpadding="0" cellspacing="0" role="none">
+      <tr>
+        <td style="width: 552px; max-width: 100%">
+          <div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
+            <a href="https://pairin.dev">
+              <img src="<%= image_url('logo.svg') %>" width="70" alt="Pairin" style="max-width: 100%; vertical-align: middle">
+            </a>
+          </div>
+          <table style="width: 100%;" cellpadding="0" cellspacing="0" role="none">
+            <tr>
+              <td class="sm-px-6" style="border-radius: 4px; background-color: #fffffe; padding: 48px; font-size: 16px; color: #334155; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)">
+                <h1 class="sm-leading-8" style="margin: 0 0 24px; font-size: 24px; font-weight: 600; color: #000001">
+                  Hello,
+                </h1>
+                <p style="margin: 0; line-height: 24px">
+                  Your pair programming session for &ldquo;<%= @session.sessionable.subject %>&rdquo; has ended and we haven't heard from you yet.
+                  <br>
+                  <br>
+                  Take a minute to leave your retro feedback so your partner can see how it went.
+                </p>
+                <p style="margin-top: 32px; text-align: center">
+                  <a href="<%= new_session_feedback_url(session_id: @session.id) %>" style="display: inline-block; padding: 12px 24px; border-radius: 4px; background-color: #4338ca; color: #ffffff; text-decoration: none; font-weight: 600">
+                    Leave your retro
+                  </a>
+                </p>
+                <p style="margin-top: 32px; font-weight: 600">Happy Pairin!</p>
+              </td>
+            </tr>
+            <tr role="separator">
+              <td style="line-height: 48px">&zwj;</td>
+            </tr>
+            <tr>
+              <td style="padding-left: 24px; padding-right: 24px; text-align: center; font-size: 12px; color: #475569">
+                <p style="margin: 0 0 16px">
+                  Pairin Team
+                </p>
+                <p style="margin: 0; font-style: italic">
+                  Find pair programming partner quick and easy
+                </p>
+                <p style="cursor: default">
+                  <a href="https://pairin.dev" class="hover-important-text-decoration-underline" style="color: #4338ca; text-decoration: none">Pairin</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/config/locales/activities/en.yml
+++ b/config/locales/activities/en.yml
@@ -137,3 +137,12 @@ en:
         - Nobody has joined your pair request within the wait time you set. Head back to your request whenever you're ready to keep waiting a bit longer.
         - Your request has been live for a while with no takers yet. Visit your request page to extend the wait time if you'd like to keep it open.
         - Still no one has joined your request. You can extend the wait time from your request page whenever you're ready.
+    retro_nag:
+      titles:
+        - Don't forget to leave feedback!
+        - Your retro is waiting for you
+        - How did your last session go?
+      content:
+        - Your last pairing session has ended and we haven't heard from you yet. Take a minute to leave your retro feedback.
+        - Don't forget to share your retro for your last session—it only takes a minute.
+        - You still have feedback to leave for your last pairing session. Head back and let us know how it went.

--- a/spec/jobs/session_feedback_nag_job_spec.rb
+++ b/spec/jobs/session_feedback_nag_job_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe SessionFeedbackNagJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.perform_now(session.id) }
+
+    let(:session) { create(:session, :past) }
+
+    it "creates an activity for each participant missing feedback" do
+      expect { perform }.to change { Activity.count }.by(2)
+
+      activities = Activity.last(2)
+
+      expect(activities.map(&:receiver)).to match_array(session.participants)
+      expect(activities).to all(have_attributes(
+        title: be_in(I18n.t("activities.retro_nag.titles")),
+        content: be_in(I18n.t("activities.retro_nag.content"))
+      ))
+    end
+
+    it "sends the retro nag mailer to each participant missing feedback" do
+      expect { perform }.to have_enqueued_mail(SessionMailer, :retro_nag_email).twice
+    end
+
+    context "when the session has been destroyed" do
+      before { session.destroy! }
+
+      it "does not raise and does not create an activity" do
+        expect { perform }.not_to change { Activity.count }
+      end
+
+      it "does not send mail" do
+        expect { perform }.not_to have_enqueued_mail(SessionMailer, :retro_nag_email)
+      end
+    end
+
+    context "when a participant already submitted feedback" do
+      let(:already_submitted) { session.participants.first }
+
+      before { create(:session_feedback, session:, participant: already_submitted) }
+
+      it "only nags the participant missing feedback" do
+        expect { perform }.to change { Activity.count }.by(1)
+
+        expect(Activity.last.receiver).to eq(session.other_participant(already_submitted))
+      end
+
+      it "only sends mail to the participant missing feedback" do
+        expect { perform }.to have_enqueued_mail(SessionMailer, :retro_nag_email).once
+      end
+    end
+
+    context "when all participants already submitted feedback" do
+      before do
+        session.participants.each { |participant| create(:session_feedback, session:, participant:) }
+      end
+
+      it "does not create an activity" do
+        expect { perform }.not_to change { Activity.count }
+      end
+
+      it "does not send mail" do
+        expect { perform }.not_to have_enqueued_mail(SessionMailer, :retro_nag_email)
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/session_mailer_preview.rb
+++ b/spec/mailers/previews/session_mailer_preview.rb
@@ -3,4 +3,8 @@ class SessionMailerPreview < ActionMailer::Preview
   def session_scheduled_email
     SessionMailer.with(session: Session.first, participant: User.find(12)).session_scheduled_email
   end
+
+  def retro_nag_email
+    SessionMailer.with(session: Session.first, participant: User.find(12)).retro_nag_email
+  end
 end

--- a/spec/mailers/session_spec.rb
+++ b/spec/mailers/session_spec.rb
@@ -1,5 +1,19 @@
 require "rails_helper"
 
 RSpec.describe SessionMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#retro_nag_email" do
+    subject(:mail) { described_class.with(session:, participant:).retro_nag_email }
+
+    let(:session) { create(:session, :past) }
+    let(:participant) { session.participants.first }
+
+    it "renders the headers" do
+      expect(mail.to).to eq [participant.email]
+      expect(mail.subject).to eq "Don't forget to leave feedback for your last session"
+    end
+
+    it "renders the session subject in the body" do
+      expect(mail.body.encoded).to match(session.sessionable.subject)
+    end
+  end
 end

--- a/spec/services/offers/accept_spec.rb
+++ b/spec/services/offers/accept_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Offers::Accept, type: :unit do
       expect { call }.to have_enqueued_mail(SessionMailer, :session_scheduled_email).twice
     end
 
+    it "schedules the retro nag job for 5 minutes after the session ends" do
+      expect { call }
+        .to have_enqueued_job(SessionFeedbackNagJob)
+        .with(kind_of(Integer))
+        .at(offer.period.end_at + 5.minutes)
+    end
+
     context "when failure" do
       context "when pair request already have accepted offer" do
         before { create(:offer, :accepted, pair_request: offer.pair_request) }


### PR DESCRIPTION
## Summary
- Adds `SessionFeedbackNagJob`: for a session that has ended, nags each participant missing retro feedback once via an `Activity` + `SessionMailer#retro_nag_email`; no-ops if the session was destroyed or the participant already left feedback.
- `Offers::Accept#schedule_session` schedules the job at `session.end_at + 5.minutes`, right after `Session.create!`.
- Adds `en.activities.retro_nag` locale keys, the `retro_nag_email` view (mirrors the existing `immediate_expired_email` template), and a mailer preview.

Closes #94.

## Test plan
- [x] `bundle exec rspec spec/jobs/session_feedback_nag_job_spec.rb spec/mailers/session_spec.rb spec/services/offers/accept_spec.rb`
- [x] Full suite: `bundle exec rspec` (0 failures)
- [x] Reviewed via `/code-review` (scoped to this branch's diff) — no P0/P1 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuxNsCyZpYCmgK3TGu124F
