### PR TITLE
Public session summaries browse page (#95)

### DIFF
--- a/app/controllers/session_feedbacks_controller.rb
+++ b/app/controllers/session_feedbacks_controller.rb
@@ -35,6 +35,6 @@ class SessionFeedbacksController < ApplicationController
   private
 
   def session_feedback_params
-    params.require(:session_feedback).permit(:session_id, :went_well, :learned, :notes, :code_snippet, :code_snippet_language)
+    params.require(:session_feedback).permit(:session_id, :went_well, :learned, :notes, :code_snippet, :code_snippet_language, :shared_publicly)
   end
 end

--- a/app/controllers/session_summaries_controller.rb
+++ b/app/controllers/session_summaries_controller.rb
@@ -5,6 +5,7 @@ class SessionSummariesController < ApplicationController
   def index
     base = PairRequest
       .eager_load(sessions: { session_feedbacks: :participant })
+      .includes(:tags)
       .with_completed_session
 
     @q = base.ransack(params[:q]&.compact_blank)

--- a/app/controllers/session_summaries_controller.rb
+++ b/app/controllers/session_summaries_controller.rb
@@ -1,0 +1,24 @@
+class SessionSummariesController < ApplicationController
+  include Authenticated
+  include Alba::Inertia::Controller
+
+  def index
+    base = PairRequest
+      .eager_load(sessions: { session_feedbacks: :participant })
+      .with_completed_session
+
+    @q = base.ransack(params[:q]&.compact_blank)
+    @pagy, @pair_requests = pagy(
+      @q.result(distinct: true).order("sessions.end_at DESC"),
+      items: 15,
+      overflow: :empty_page,
+    )
+
+    render inertia: "SessionSummaries/Index", props: {
+      sessionSummariesCount: @pagy.count,
+      sessionSummaries: InertiaRails.scroll(@pagy) {
+        SessionSummaryResource.new(@pair_requests)
+      }
+    }
+  end
+end

--- a/app/javascript/components/MainNav.jsx
+++ b/app/javascript/components/MainNav.jsx
@@ -8,6 +8,7 @@ import {
   Send,
   Rss,
   CalendarClock,
+  BookOpen,
   ChevronDown,
   LogOut,
   Menu,
@@ -21,6 +22,7 @@ const NAV_ITEMS = [
   { href: "/pair_requests", label: "Search", icon: Search },
   { href: "/activities", label: "Feed", icon: Rss },
   { href: "/sessions", label: "Sessions", icon: CalendarClock },
+  { href: "/session_summaries", label: "Summaries", icon: BookOpen },
 ];
 
 const PAIR_REQUEST_SUBMENU = [
@@ -91,6 +93,7 @@ function NavContent({ currentPath, currentUser, onNavigate }) {
 
           <NavLink {...NAV_ITEMS[1]} active={isActive(NAV_ITEMS[1].href)} onClick={onNavigate} />
           <NavLink {...NAV_ITEMS[2]} active={isActive(NAV_ITEMS[2].href)} onClick={onNavigate} />
+          <NavLink {...NAV_ITEMS[3]} active={isActive(NAV_ITEMS[3].href)} onClick={onNavigate} />
         </div>
       </nav>
 

--- a/app/javascript/pages/SessionFeedbacks/New.jsx
+++ b/app/javascript/pages/SessionFeedbacks/New.jsx
@@ -17,6 +17,7 @@ const humanize = (value) => value.charAt(0).toUpperCase() + value.slice(1);
 
 export default function New({ sessionId, subject, otherParticipantName, wentWellValues }) {
   const [wentWell, setWentWell] = useState("");
+  const [sharedPublicly, setSharedPublicly] = useState(false);
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 pb-16 md:px-8">
@@ -25,7 +26,7 @@ export default function New({ sessionId, subject, otherParticipantName, wentWell
       <PageHeader
         eyebrow="Retro"
         title={subject || "How did it go?"}
-        description={otherParticipantName ? `Share a private retro on your session with ${otherParticipantName}. Only you and your partner can see this.` : "Share a private retro on this session."}
+        description={otherParticipantName ? `Share a retro on your session with ${otherParticipantName}. By default, only you and your partner can see this.` : "Share a retro on this session. By default, only you can see this."}
       />
 
       <Form method="post" action="/session_feedbacks" className="flex flex-col items-stretch">
@@ -102,6 +103,36 @@ export default function New({ sessionId, subject, otherParticipantName, wentWell
               {errors.code_snippet_language && (
                 <div className="text-red font-bold mt-1 text-sm">{errors.code_snippet_language}</div>
               )}
+            </div>
+
+            <div className="w-full mt-4">
+              <Label className="block mb-1">Visibility</Label>
+              <input type="hidden" name="shared_publicly" value={sharedPublicly ? "true" : "false"} />
+              <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Visibility">
+                <Button
+                  type="button"
+                  role="radio"
+                  aria-checked={!sharedPublicly}
+                  variant={!sharedPublicly ? "default" : "neutral"}
+                  onClick={() => setSharedPublicly(false)}
+                >
+                  <span className="mr-1.5">🔒</span>
+                  Private
+                </Button>
+                <Button
+                  type="button"
+                  role="radio"
+                  aria-checked={sharedPublicly}
+                  variant={sharedPublicly ? "default" : "neutral"}
+                  onClick={() => setSharedPublicly(true)}
+                >
+                  <span className="mr-1.5">🌐</span>
+                  Public
+                </Button>
+              </div>
+              <p className="mt-1 text-xs text-black/50">
+                Public retros appear in Session Summaries, visible to any signed-in user. Private stays between you and your partner.
+              </p>
             </div>
 
             <Button type="submit" size="lg" disabled={processing} className="mt-10 self-center">

--- a/app/javascript/pages/SessionSummaries/Card.jsx
+++ b/app/javascript/pages/SessionSummaries/Card.jsx
@@ -1,0 +1,61 @@
+import ExpandableText from "@/components/ExpandableText";
+import { Badge } from "@/components/ui/badge";
+
+const TAG_COLORS = ["bg-purple text-white", "bg-orange text-white", "bg-green text-black"];
+
+const WENT_WELL_EMOJI = {
+  great: "🎉",
+  good: "🙂",
+  okay: "😐",
+  tough: "😓",
+};
+
+export default function SessionSummaryCard({ sessionSummary }) {
+  const feedbacks = sessionSummary.session_feedbacks ?? [];
+
+  return (
+    <div className="mb-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] md:p-6">
+      <h3 className="text-xl">{sessionSummary.subject}</h3>
+
+      <ExpandableText className="mt-3 leading-relaxed text-black/60">{sessionSummary.description}</ExpandableText>
+
+      {sessionSummary.goal && (
+        <p className="mt-3 text-sm text-black/60"><span className="font-bold text-black">Goal:</span> {sessionSummary.goal}</p>
+      )}
+
+      {sessionSummary.platform && (
+        <p className="mt-1 text-sm text-black/60"><span className="font-bold text-black">Platform:</span> {sessionSummary.platform}</p>
+      )}
+
+      {sessionSummary.plan && (
+        <p className="mt-1 text-sm text-black/60"><span className="font-bold text-black">Plan:</span> {sessionSummary.plan}</p>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {sessionSummary.tags.map((tag, i) => (
+          <Badge key={tag.id} className={`rounded-full border-black ${TAG_COLORS[i % TAG_COLORS.length]}`}>
+            {tag.name}
+          </Badge>
+        ))}
+      </div>
+
+      {feedbacks.length > 0 && (
+        <div className="mt-5 grid gap-4 border-t-2 border-black/10 pt-4 md:grid-cols-2">
+          {feedbacks.map((feedback) => (
+            <div key={feedback.participant.id} className="rounded-xl border-2 border-black/10 p-3">
+              <p className="font-bold text-sm">
+                {WENT_WELL_EMOJI[feedback.went_well]} {feedback.participant.name}
+              </p>
+              {feedback.learned && (
+                <p className="mt-1 text-sm text-black/60"><span className="font-bold text-black">Learned:</span> {feedback.learned}</p>
+              )}
+              {feedback.notes && (
+                <p className="mt-1 text-sm text-black/60"><span className="font-bold text-black">Notes:</span> {feedback.notes}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/pages/SessionSummaries/Index.jsx
+++ b/app/javascript/pages/SessionSummaries/Index.jsx
@@ -1,0 +1,45 @@
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
+import Card from "./Card";
+import { Head, InfiniteScroll } from "@inertiajs/react";
+import { BookOpen } from "lucide-react";
+
+export default function Index({ sessionSummaries, sessionSummariesCount }) {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 pb-16 md:px-8">
+      <Head title="Session Summaries" />
+
+      <PageHeader
+        eyebrow="Knowledge base"
+        title="Session Summaries"
+        description="Browse retros from completed pairing sessions across the community."
+      />
+
+      <div className="relative mt-8 flex flex-col gap-6">
+        <InfiniteScroll
+          data="sessionSummaries"
+          loading={() => (
+            <div className="flex justify-center py-8 font-bold text-black/50">Loading more...</div>
+          )}
+          next={({ hasMore }) =>
+            !hasMore && sessionSummaries.length > 0 ? (
+              <div className="flex justify-center py-8 text-black/40">No more summaries</div>
+            ) : null
+          }
+        >
+          {sessionSummaries.map((summary) => (
+            <Card key={summary.id} sessionSummary={summary} />
+          ))}
+        </InfiniteScroll>
+
+        {sessionSummariesCount === 0 && (
+          <EmptyState
+            icon={BookOpen}
+            title="No session summaries yet"
+            description="Once sessions wrap up and retros come in, they'll show up here."
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -21,6 +21,7 @@ class PairRequest < ApplicationRecord
 
   scope :active, -> { joins(:periods).merge(Period.future).where(cancelled_at: nil) }
   scope :scheduled_active, -> { active.where(mode: "scheduled") }
+  scope :with_completed_session, -> { joins(:sessions).merge(Session.past).distinct }
   scope :live_now, lambda {
     joins(:periods)
       .where(mode: "immediate", cancelled_at: nil)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -11,6 +11,7 @@ class Session < ApplicationRecord
   validate :dates_in_future, :dates_in_order
 
   scope :future, -> { where(start_at: Time.current..) }
+  scope :past, -> { where(end_at: ...Time.current) }
 
   def hold_by_user?(user)
     holder == user

--- a/app/models/session_feedback.rb
+++ b/app/models/session_feedback.rb
@@ -10,6 +10,8 @@ class SessionFeedback < ApplicationRecord
   validates :participant_id, uniqueness: { scope: :session_id }
   validate :session_has_ended
 
+  scope :shared_publicly, -> { where(shared_publicly: true) }
+
   private
 
   def session_has_ended

--- a/app/resources/session_summary_resource.rb
+++ b/app/resources/session_summary_resource.rb
@@ -1,0 +1,22 @@
+class SessionSummaryResource < ApplicationResource
+  attributes :id, :subject, :description, :goal, :platform, :plan
+
+  many :tags, resource: TagResource
+
+  attribute :session_feedbacks do |pair_request|
+    session = pair_request.sessions.select { |s| s.end_at <= Time.current }.max_by(&:end_at)
+    next [] unless session
+
+    session.session_feedbacks.select(&:shared_publicly?).map do |feedback|
+      {
+        went_well: feedback.went_well,
+        learned: feedback.learned,
+        notes: feedback.notes,
+        participant: {
+          id: feedback.participant_id,
+          name: feedback.participant.name
+        }
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :sessions, only: [:index, :update]
+  resources :session_summaries, only: [:index]
   resources :profiles, only: [:show, :update]
 
   resources :pair_requests, only: [:index] do

--- a/db/migrate/20260804060204_add_shared_publicly_to_session_feedbacks.rb
+++ b/db/migrate/20260804060204_add_shared_publicly_to_session_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddSharedPubliclyToSessionFeedbacks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :session_feedbacks, :shared_publicly, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260804060219_add_index_on_sessions_end_at.rb
+++ b/db/migrate/20260804060219_add_index_on_sessions_end_at.rb
@@ -1,0 +1,5 @@
+class AddIndexOnSessionsEndAt < ActiveRecord::Migration[7.1]
+  def change
+    add_index :sessions, :end_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_04_035828) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_04_060219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_035828) do
     t.string "code_snippet_language"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "shared_publicly", default: false, null: false
     t.index ["participant_id"], name: "index_session_feedbacks_on_participant_id"
     t.index ["session_id", "participant_id"], name: "index_session_feedbacks_on_session_id_and_participant_id", unique: true
     t.index ["session_id"], name: "index_session_feedbacks_on_session_id"
@@ -98,6 +99,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_035828) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "call_link"
+    t.index ["end_at"], name: "index_sessions_on_end_at"
     t.index ["sessionable_type", "sessionable_id"], name: "index_sessions_on_sessionable"
   end
 

--- a/spec/factories/session_feedbacks.rb
+++ b/spec/factories/session_feedbacks.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     went_well { SessionFeedback::WENT_WELL_VALUES.sample }
     learned { Faker::Lorem.sentence(word_count: 10) }
     notes { Faker::Lorem.sentence(word_count: 10) }
+
+    trait :shared_publicly do
+      shared_publicly { true }
+    end
   end
 end

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe PairRequest, type: :model do
         expect(live_now).to contain_exactly(live_request)
       end
     end
+
+    describe ".with_completed_session" do
+      subject(:with_completed_session) { described_class.with_completed_session }
+
+      let!(:completed_request) { create(:session, :past).sessionable }
+      let!(:upcoming_request) { create(:session).sessionable }
+      let!(:no_session_request) { create(:pair_request) }
+
+      it "returns only pair requests with a session that has ended" do
+        expect(with_completed_session).to contain_exactly(completed_request)
+      end
+    end
   end
 
   describe "#has_accepted_offer?" do

--- a/spec/models/session_feedback_spec.rb
+++ b/spec/models/session_feedback_spec.rb
@@ -65,4 +65,15 @@ RSpec.describe SessionFeedback, type: :model do
       end
     end
   end
+
+  describe "scopes" do
+    describe ".shared_publicly" do
+      subject(:shared_publicly) { described_class.shared_publicly }
+
+      let!(:public_feedback) { create(:session_feedback, :shared_publicly) }
+      let!(:private_feedback) { create(:session_feedback) }
+
+      it { is_expected.to contain_exactly(public_feedback) }
+    end
+  end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Session, type: :model do
 
       it { is_expected.to contain_exactly(future_session) }
     end
+
+    describe ".past" do
+      subject(:past) { described_class.past }
+
+      let!(:past_session) { create(:session, :past) }
+      let!(:future_session) { create(:session) }
+
+      it { is_expected.to contain_exactly(past_session) }
+    end
   end
 
   describe "validations" do

--- a/spec/requests/session_summaries_spec.rb
+++ b/spec/requests/session_summaries_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "SessionSummaries", type: :request do
+  describe "GET /index" do
+    subject(:index) { get session_summaries_path }
+
+    let(:current_user) { create(:user) }
+
+    before { sign_in current_user }
+
+    it "returns http success" do
+      index
+
+      expect(response).to have_http_status(:success)
+    end
+
+    context "when the current user is not a participant of the completed session" do
+      let!(:session) { create(:session, :past) }
+
+      it "still includes the session's pair request" do
+        index
+
+        expect(response.body).to include(session.sessionable.subject)
+      end
+    end
+  end
+end

--- a/spec/system/session_feedbacks/create_spec.rb
+++ b/spec/system/session_feedbacks/create_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe "submit session feedback", type: :system do
       expect(feedback.learned).to eq("Learned a ton about pairing")
     end
 
+    it "defaults to keeping the retro private" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      click_button "Great"
+      click_button "Submit retro"
+
+      feedback = session.session_feedbacks.find_by!(participant: current_user)
+      expect(feedback.shared_publicly).to be false
+    end
+
+    it "shares the retro publicly when the user opts in" do
+      visit new_session_feedback_path(session_id: session.id)
+
+      click_button "Great"
+      click_button "Public"
+      click_button "Submit retro"
+
+      feedback = session.session_feedbacks.find_by!(participant: current_user)
+      expect(feedback.shared_publicly).to be true
+    end
+
     it "allows submitting without picking a reaction" do
       visit new_session_feedback_path(session_id: session.id)
 

--- a/spec/system/session_summaries/index_spec.rb
+++ b/spec/system/session_summaries/index_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe "display session summaries", type: :system do
+  let(:current_user) { create(:user) }
+
+  before { sign_in(current_user) }
+
+  context "when a completed session has feedback from both participants, shared publicly" do
+    let!(:session) { create(:session, :past) }
+    let(:pair_request) { session.sessionable }
+    let(:participant_1) { session.participants.first }
+    let(:participant_2) { session.participants.second }
+
+    before do
+      pair_request.update!(subject: "Refactor the payments module", goal: "Learn TDD", platform: "zoom")
+      participant_1.update!(name: "Alex Morgan")
+      participant_2.update!(name: "Jamie Lee")
+      create(:session_feedback, :shared_publicly, session:, participant: participant_1, went_well: "great", learned: "Extract method")
+      create(:session_feedback, :shared_publicly, session:, participant: participant_2, went_well: "tough", learned: "Merge conflicts are hard")
+    end
+
+    it "shows the pair request details and both participants' retros side by side" do
+      visit session_summaries_path
+
+      expect(page).to have_content("Refactor the payments module")
+      expect(page).to have_content("Learn TDD")
+      expect(page).to have_content("zoom")
+      expect(page).to have_content(participant_1.name)
+      expect(page).to have_content("Extract method")
+      expect(page).to have_content(participant_2.name)
+      expect(page).to have_content("Merge conflicts are hard")
+    end
+  end
+
+  context "when only one participant has shared their retro publicly" do
+    let!(:session) { create(:session, :past) }
+    let(:pair_request) { session.sessionable }
+    let(:participant_1) { session.participants.first }
+    let(:participant_2) { session.participants.second }
+
+    before do
+      pair_request.update!(subject: "Debug the flaky spec")
+      participant_1.update!(name: "Sam Rivera")
+      participant_2.update!(name: "Priya Patel")
+      create(:session_feedback, :shared_publicly, session:, participant: participant_1, went_well: "good", learned: "Timing issue")
+      create(:session_feedback, session:, participant: participant_2, went_well: "tough", learned: "Kept this one private")
+    end
+
+    it "renders only the retro that was shared publicly" do
+      visit session_summaries_path
+
+      expect(page).to have_content("Debug the flaky spec")
+      expect(page).to have_content(participant_1.name)
+      expect(page).to have_content("Timing issue")
+      expect(page).not_to have_content(participant_2.name)
+      expect(page).not_to have_content("Kept this one private")
+    end
+  end
+
+  context "when feedback exists but nobody has shared it publicly" do
+    let!(:session) { create(:session, :past) }
+    let(:pair_request) { session.sessionable }
+    let(:participant_1) { session.participants.first }
+
+    before do
+      pair_request.update!(subject: "Pair on the auth flow")
+      create(:session_feedback, session:, participant: participant_1, went_well: "okay", learned: "Should stay hidden")
+    end
+
+    it "still shows the pair request but no retro content" do
+      visit session_summaries_path
+
+      expect(page).to have_content("Pair on the auth flow")
+      expect(page).not_to have_content("Should stay hidden")
+    end
+  end
+
+  context "when the current user is not a participant of the session" do
+    let!(:session) { create(:session, :past, with_holder: false, with_partner: false) }
+
+    before { session.sessionable.update!(subject: "Someone else's session") }
+
+    it "is still reachable and shows the summary" do
+      visit session_summaries_path
+
+      expect(page).to have_content("Someone else's session")
+    end
+  end
+
+  context "when no sessions have ended yet" do
+    let!(:upcoming_session) { create(:session) }
+
+    it "shows an empty state" do
+      visit session_summaries_path
+
+      expect(page).to have_content("No session summaries yet")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `SessionSummariesController#index`: a public knowledge-base browse page reachable by any signed-in user, showing completed pairing sessions (subject/description/goal/platform/plan/tags), queried from `PairRequest` outward via a new `.with_completed_session` scope (`joins(:sessions).merge(Session.past)`), reusing `PairRequest`'s existing `ransackable_associations`/`ransackable_attributes` unchanged. Same Ransack+Pagy+`InertiaRails.scroll` shape as `PairRequestsController#index`.
- New `SessionSummaries/Index.jsx` + `Card.jsx` (near-copy of the `PairRequests` browse shell), rendering both participants' retros side by side; retro stays optional if not (yet) shared.
- **Privacy:** retro feedback is private by default. Added an opt-in `shared_publicly` boolean on `session_feedbacks` (default `false`) and a Private/Public toggle on the retro submission form (`SessionFeedbacks/New.jsx`), with copy updated to honestly describe what "public" means (visible in Session Summaries to any signed-in user). `SessionSummaryResource` only serializes feedback where `shared_publicly` is true — a participant's retro never appears here unless they explicitly opted in. This resolves a conflict flagged in review between this issue's "public knowledge base" requirement and the existing retro form's original privacy promise (confirmed resolution approach with the reporter).
- Added `Session.past` scope and a DB index on `sessions.end_at` backing it.
- Added a "Summaries" link to `MainNav`.

Closes #95.

## Test plan
- [x] `bundle exec rspec` — full suite, 217 examples, 0 failures
- [x] New specs cover: both participants shared publicly, one shared/one private (private content never renders), feedback exists but unshared (pair request still lists, no retro content), non-participant can still view the summary, empty state, and the retro form's default-private / opt-in-public submission paths
- [x] Reviewed via `/code-review` (scoped to this branch's diff), including a follow-up re-review after the privacy fix — no P0/P1 findings remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuxNsCyZpYCmgK3TGu124F
